### PR TITLE
Fix zero divisions in workplace calculations

### DIFF
--- a/R/class_country.R
+++ b/R/class_country.R
@@ -157,6 +157,8 @@ daedalus_country <- function(name,
 
   # substitute defaults with non-NULL elements of parameters
   params <- daedalus::country_data[[name]]
+  # add one worker to each sector to avoid division by zero
+  params$workers <- params$workers + 1
   # calculate consumer-worker contacts
   contacts_consumer_worker <- matrix(
     daedalus::economic_contacts[["contacts_workplace"]],

--- a/man/daedalus.Rd
+++ b/man/daedalus.Rd
@@ -12,7 +12,8 @@ daedalus(
   response_time = 30,
   response_threshold = 1000,
   initial_state_manual = list(),
-  time_end = 300
+  time_end = 300,
+  ...
 )
 }
 \arguments{
@@ -65,6 +66,9 @@ Defaults to \code{1e-6} and \code{0.0} respectively.}
 \item{time_end}{An integer-like value for the number of timesteps
 at which to return data. This is treated as the number of days with data
 returned for each day. Defaults to 300 days.}
+
+\item{...}{Other arguments to be passed to the ODE solver; these are passed
+to \code{\link[deSolve:ode]{deSolve::ode()}}.}
 }
 \value{
 A \verb{<deSolve>} object.

--- a/tests/testthat/test-daedalus.R
+++ b/tests/testthat/test-daedalus.R
@@ -50,13 +50,21 @@ test_that("daedalus: basic expectations", {
 })
 
 # test that daedalus runs for all epidemic infection parameter sets
-test_that("daedalus: Runs for all epidemics", {
-  epidemics <- lapply(daedalus::epidemic_names, daedalus_infection)
+test_that("daedalus: Runs for all country x infection x response", {
+  country_infection_combos <- data.table::CJ(
+    country = daedalus::country_names,
+    infection = daedalus::epidemic_names
+  )
+  time_end <- 50
+
   # expect no conditions
   expect_no_condition({
-    output_list <- lapply(
-      epidemics, daedalus,
-      country = country_canada, time_end = 50
+    Map(
+      country_infection_combos$country,
+      country_infection_combos$infection,
+      f = function(x, y) {
+        daedalus(x, y)
+      }
     )
   })
 

--- a/tests/testthat/test-daedalus.R
+++ b/tests/testthat/test-daedalus.R
@@ -55,26 +55,19 @@ test_that("daedalus: Runs for all country x infection x response", {
     country = daedalus::country_names,
     infection = daedalus::epidemic_names
   )
-  time_end <- 50
+  time_end <- 10
 
   # expect no conditions
-  expect_no_condition({
+  invisible(
     Map(
       country_infection_combos$country,
       country_infection_combos$infection,
       f = function(x, y) {
-        daedalus(x, y)
+        expect_no_condition(
+          daedalus(x, y, time_end = time_end, response_time = time_end - 2)
+        )
       }
     )
-  })
-
-  # expect classed output, type double, and non-negative
-  checkmate::expect_list(output_list, "daedalus_output")
-  expect_true(
-    all(vapply(output_list, function(x) {
-      x <- get_data(x)
-      all(x$value >= 0.0)
-    }, FUN.VALUE = logical(1)))
   )
 })
 


### PR DESCRIPTION
This is a draft PR that fixes an issue where the model failed for some countries as below:

``` r
daedalus::daedalus("Australia", "sars_cov_1")
#> DLSODAR-  At start of problem, too much accuracy  
#>       requested for precision of machine..  See TOLSF (=R1) ?d
#> In above message, R1 = nan
#> 
#> Error in lsodar(y, times, func, parms, rtol, atol, jacfunc, jactype, rootfunc, : illegal input detected before taking any integration steps - see written message
```

The reason was division by zero when calculating proportions of infectious workers for workplace infections, as some countries have zero workers in some sectors.

The fix has been to add a single worker to each sector in `daedalus_country()` - this is called internally on country name strings.

This PR _also_ adds `...` to `daedalus()` to allow passing solver options to `deSolve::ode()`, which includes changing the solver. Previously the model was fixed to using the LSODA solver. Note that some solver methods are not compatible with the use of events which are used to handle response measures.