### PR TITLE
Add vaccination switch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: daedalus
 Title: Model health, social, and economic costs of a pandemic using
     _DAEDALUS_
-Version: 0.0.15
+Version: 0.0.16
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# daedalus 0.0.18
+
+This patch fixes an issue where vaccination start was tied to the `response_time`; it is now correctly controlled by the vaccine investment level passed to `daedalus()`.
+
+- Added a `vax_switch` which is manually turned on in stage 03 of the model (never turned off);
+
+- Added test to check that there is no vaccination before scenario-defined start times;
+
+- Added tests to check that vaccine investment levels control epidemic deaths.
+
 # daedalus 0.0.15
 
 This patch fixes an issue where closures were not ended in model runs where the closure began after the epidemic had stopped growing. This mostly affected edge cases of countries with large spare hospital capacity, and relatively late `response_time`s. In such cases the closure end time was assigned as the simulation end time, inflating costs related to closures. The fix:

--- a/R/daedalus.R
+++ b/R/daedalus.R
@@ -318,6 +318,11 @@ daedalus <- function(country,
   # reset min time
   parameters[["min_time"]] <- vaccination_start
 
+  # turn vax_switch on
+  rlang::env_poke(
+    parameters[["mutables"]], "vax_switch", TRUE
+  )
+
   data_stage_03 <- deSolve::ode(
     initial_state, times_stage_03,
     daedalus_rhs, parameters,

--- a/R/model_helpers.R
+++ b/R/model_helpers.R
@@ -97,6 +97,9 @@ make_initial_state <- function(country, initial_state_manual) {
 #' - `hosp_switch`: The switch for excess mortality due to more hospitalisations
 #' required than hospital places are available.
 #'
+#' - `vax_switch`: A switch for whether vaccination is active. Manually switched
+#' on in model stage 3.
+#'
 #' - `closures_time_start` and `closures_time_end`: The times at which closures
 #' start and end. Defaults to the end time of the simulation so as to
 #' give a default duration of 0.0.
@@ -109,7 +112,8 @@ prepare_mutable_parameters <- function() {
     # to later process duration as time_start - time_end
     closure_time_start = 0.0,
     closure_time_end = 0.0,
-    hosp_switch = FALSE
+    hosp_switch = FALSE,
+    vax_switch = FALSE
   )
 
   env

--- a/R/ode.R
+++ b/R/ode.R
@@ -90,7 +90,8 @@ daedalus_rhs <- function(t, state, parameters) {
 
   # NOTE: scale vax rate by proportion of eligible individuals remaining
   # to maintain rate relative to total population as eligibles decrease
-  nu <- if (switch) scale_nu(state_, nu, vax_uptake_limit) else 0.0
+  vax_switch <- rlang::env_get(parameters[["mutables"]], "vax_switch")
+  nu <- if (vax_switch) scale_nu(state_, nu, vax_uptake_limit) else 0.0
 
   # create empty array of the dimensions of state
   d_state <- array(0.0, dim(state_))

--- a/man/prepare_mutable_parameters.Rd
+++ b/man/prepare_mutable_parameters.Rd
@@ -13,6 +13,8 @@ An environment with three mutable parameters:
 or not.
 \item \code{hosp_switch}: The switch for excess mortality due to more hospitalisations
 required than hospital places are available.
+\item \code{vax_switch}: A switch for whether vaccination is active. Manually switched
+on in model stage 3.
 \item \code{closures_time_start} and \code{closures_time_end}: The times at which closures
 start and end. Defaults to the end time of the simulation so as to
 give a default duration of 0.0.

--- a/tests/testthat/test-vaccination.R
+++ b/tests/testthat/test-vaccination.R
@@ -1,7 +1,8 @@
 # Tests for daedalus() with vaccination active
 test_that("Vaccination: basic expectations", {
+  vax_level <- daedalus_vaccination("medium")
   expect_no_condition({
-    output <- daedalus("Canada", "sars_cov_1", vaccine_investment = "medium")
+    output <- daedalus("Canada", "sars_cov_1", vaccine_investment = vax_level)
   })
   data <- get_data(output)
 
@@ -9,6 +10,14 @@ test_that("Vaccination: basic expectations", {
   expect_gt(
     max(data_vaccinated$value), 0
   )
+
+  # expect that there are no vaccinations before the vaccination start time
+  t_vax <- get_data(vax_level, "vax_start_time")
+  vax_per_day <- tapply(data_vaccinated$value, data_vaccinated$time, sum)
+  expect_identical(
+    max(vax_per_day[seq_len(t_vax)]), 0.0
+  )
+
 
   # expect that vaccination does not affect population size
   data_start <- data[data$time == min(data$time), ]


### PR DESCRIPTION
This PR fixes an issue where vaccination start was tied to the `response_time`; it is now correctly controlled by the vaccine investment level passed to `daedalus()`.

- Added a `vax_switch` to the mutable parameters (although it is not currently modified within integration steps). It is manually turned on in stage 03 of the model (never turned off);
- Added test to check that there is no vaccination before scenario-defined start times;
- Added tests to check that vaccine investment levels control epidemic deaths.

**Note:** Versioning needs to be fixed depending on merge order wrt #35.