### PR TITLE
Correct community infectious and remove between-sector infections

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ URL: https://github.com/j-idea/daedalus,
     https://jameel-institute.github.io/daedalus/
 BugReports: https://github.com/j-idea/daedalus/issues
 Depends: 
-    R (>= 4.3)
+    R (>= 2.10)
 Imports: 
     checkmate,
     cli,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: daedalus
 Title: Model health, social, and economic costs of a pandemic using
     DAEDALUS
-Version: 0.0.19
+Version: 0.0.20
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+# daedalus 0.0.20
+
+This patch updates the state variable in `daedalus()` to substantially reduce the number of compartments; all empty compartments have been removed. This improves the speed of model runs as there are fewer derivatives to calculate.
+
+1. State variable is a 3D array with the dimensions: `c(49, 9, 3)`. The working-age economic sectors are added on as rows after the age-groups. Epidemiological compartments are unchanged. The third dimension holds data on vaccination status, including new vaccinations.
+
+2. Helper functions are updated to support the new state dimensions.
+
+3. $R_t$ calculation in `r_eff()` has been simplified to the proportional susceptible times $R_0$, pending a more accurate calculation.
+
+4. The internal helper function `prepare_output()` has been refactored to avoid use of `base::array2DF()` to remove the dependency on newer versions of R.
+
+5. Removes unused between-sector contacts in force-of-infection calculations.
+
+6. Moves some contact scaling to the parameter preparation stage to reduce operations during the model run.
+
+7. Correctly sums the total number of infectious individuals in the community; previously, the implementation resulted in segregation by economic sector.
+
+# daedalus 0.0.19
+
+This patch adds functionality to run `daedalus()` with the `country` argument passed as one of `country_codes_iso2c` or `country_codes_iso3c` for 2 and 3 letter ISO country codes.
+
 # daedalus 0.0.18
 
 This patch adds logging of daily new vaccinations and provides an output helper function, `get_new_vaccinations()`, to get daily new vaccinations.

--- a/R/class_country.R
+++ b/R/class_country.R
@@ -430,11 +430,13 @@ prepare_parameters.daedalus_country <- function(x, ...) {
   singv <- max(Re(svd(cmcw)[["d"]]))
   cmcw <- cmcw / singv
 
+  workers <- get_data(x, "workers")
+
   list(
     demography = demography,
     contact_matrix = cm,
     cm_unscaled = cm_unscaled, # for use in Rt calculations
-    contacts_workplace = cmw,
+    contacts_workplace = cmw / workers,
     contacts_consumer_worker = cmcw,
     contacts_between_sectors = get_data(x, "contacts_between_sectors") # 0s
   )

--- a/R/class_country.R
+++ b/R/class_country.R
@@ -437,7 +437,6 @@ prepare_parameters.daedalus_country <- function(x, ...) {
     contact_matrix = cm,
     cm_unscaled = cm_unscaled, # for use in Rt calculations
     contacts_workplace = cmw / workers,
-    contacts_consumer_worker = cmcw,
-    contacts_between_sectors = get_data(x, "contacts_between_sectors") # 0s
+    contacts_consumer_worker = cmcw
   )
 }

--- a/R/class_infection.R
+++ b/R/class_infection.R
@@ -394,5 +394,15 @@ prepare_parameters.daedalus_infection <- function(x, ...) {
 
   validate_daedalus_infection(x)
   x <- unclass(x)
+
+  age_varying_params <- c("eta", "omega", "gamma_H")
+
+  x[age_varying_params] <- lapply(
+    x[age_varying_params], function(p) {
+      p <- c(p, rep(p[i_WORKING_AGE], N_ECON_SECTORS))
+      p
+    }
+  )
+
   x[names(x) != "name"]
 }

--- a/R/class_vaccination.R
+++ b/R/class_vaccination.R
@@ -282,12 +282,9 @@ scale_nu <- function(state, nu, uptake_limit) {
   # NOTE: state must be a 4D array with only vaccinated and unvaccinated layers
   # in dim 4
   total <- sum(
-    state[
-      , i_EPI_COMPARTMENTS, ,
-      c(i_VACCINATED_STRATUM, i_UNVACCINATED_STRATUM)
-    ]
+    state[, i_EPI_COMPARTMENTS, c(i_VACCINATED_STRATUM, i_UNVACCINATED_STRATUM)]
   )
-  total_vaccinated <- sum(state[, i_EPI_COMPARTMENTS, , i_VACCINATED_STRATUM])
+  total_vaccinated <- sum(state[, i_EPI_COMPARTMENTS, i_VACCINATED_STRATUM])
   prop_vaccinated <- total_vaccinated / total
 
   # NOTE: simplified scaling works only for uniform rates and start times

--- a/R/closure.R
+++ b/R/closure.R
@@ -8,10 +8,7 @@ make_response_threshold_event <- function(response_threshold) {
   # NOTE: input checking at top level
   ## event triggered when thresholds are crossed
   root_function <- function(time, state, parameters) {
-    state <- array(
-      state,
-      c(N_AGE_GROUPS, N_MODEL_COMPARTMENTS, N_ECON_STRATA, N_VACCINE_STRATA)
-    )
+    state <- values_to_state(state)
 
     get_hospitalisations(state) - response_threshold
   }

--- a/R/constants.R
+++ b/R/constants.R
@@ -69,6 +69,9 @@ N_ECON_SECTORS <- 45L
 
 #' @name model_constants
 #' @keywords model_constant
+# NOTE: state variable attaches econ sectors as rows after age groups
+# for a total of N_AGE_GROUPS + N_ECON_SECTORS rows, +1 needed to index the
+# econ sectors only.
 i_ECON_SECTORS <- seq(N_AGE_GROUPS + 1, N_AGE_GROUPS + N_ECON_SECTORS)
 
 #' @name model_constants

--- a/R/constants.R
+++ b/R/constants.R
@@ -45,6 +45,10 @@ N_AGE_GROUPS <- 4L
 
 #' @name model_constants
 #' @keywords model_constant
+i_AGE_GROUPS <- seq_len(N_AGE_GROUPS)
+
+#' @name model_constants
+#' @keywords model_constant
 N_VACCINE_STRATA <- 2L
 
 #' @name model_constants
@@ -62,6 +66,10 @@ i_WORKING_AGE <- 3L
 #' @name model_constants
 #' @keywords model_constant
 N_ECON_SECTORS <- 45L
+
+#' @name model_constants
+#' @keywords model_constant
+i_ECON_SECTORS <- seq(N_AGE_GROUPS + 1, N_AGE_GROUPS + N_ECON_SECTORS)
 
 #' @name model_constants
 #' @keywords model_constant

--- a/R/costs.R
+++ b/R/costs.R
@@ -63,7 +63,7 @@ get_costs <- function(x, summarise_as = c("none", "total", "domain")) {
   )
 
   # absences due to infection, hospitalisation, death
-  model_data <- x$model_data
+  model_data <- get_data(x)
   worker_absences <- model_data[
     model_data$compartment %in%
       c("infect_symp", "infect_asymp", "hospitalised", "dead") &

--- a/R/daedalus.R
+++ b/R/daedalus.R
@@ -276,11 +276,12 @@ daedalus <- function(country,
   # close intervention IFF epidemic is not growing
   # NOTE: this step placed here as a conditional on r_eff < 1.0 is not
   # practical in a root-finding function (Error: 'root too near initial point')
-  is_epidemic_growing <- r_eff(
+  rt <- r_eff(
     parameters[["r0"]],
     state_temp,
     parameters[["cm_unscaled"]]
-  ) >= 1.0
+  )
+  is_epidemic_growing <- rt >= 1.0
 
   if (!is_epidemic_growing) {
     rlang::env_bind(

--- a/R/model_helpers.R
+++ b/R/model_helpers.R
@@ -1,13 +1,21 @@
 #' @title Generate a default initial state for DAEDALUS
-#' @description Function to prepare the model initial state.
+#' @description Function to prepare the model initial state. Assumes that
+#' 1 in every million individuals is initially infected, and that 60% are
+#' asymptomatic infections. This does not affect the actual probability of
+#' asymptomatic infections in the simulation, which is a property of a
+#' `<daedalus_infection>`.
 #'
 #' @inheritParams daedalus
 #'
-#' @return An array with as many dimensions as `N_ECON_STRATA` (currently, 46)
-#' with each layer giving the proportion of individuals of each group in each
-#' epidemiological compartment.
+#' @return An array with as many dimensions as `N_VACCINE_DATA_GROUPS`
+#' (currently, 3); rows specify the age and economic groups, columns specify the
+#' epidemiological compartments (including new infections and hospitalisations),
+#' and array layers hold information on vaccination status (including new
+#' vaccinations).
 #' @keywords internal
-make_initial_state <- function(country, initial_state_manual) {
+make_initial_state <- function(
+    country,
+    initial_state_manual) {
   # NOTE: country checked in daedalus()
   initial_infect_state <- list(
     p_infectious = 1e-6,

--- a/R/model_helpers.R
+++ b/R/model_helpers.R
@@ -139,8 +139,9 @@ get_closure_info <- function(mutables) {
 #' @return An array of dimensions (4, 9, 46, 3).
 #' @keywords internal
 values_to_state <- function(x) {
-  array(
-    x,
-    c(N_AGE_GROUPS, N_MODEL_COMPARTMENTS, N_ECON_STRATA, N_VACCINE_DATA_GROUPS)
+  dim(x) <- c(
+    N_AGE_GROUPS + N_ECON_SECTORS, N_MODEL_COMPARTMENTS, N_VACCINE_DATA_GROUPS
   )
+
+  x
 }

--- a/R/ode.R
+++ b/R/ode.R
@@ -123,9 +123,7 @@ daedalus_rhs <- function(t, state, parameters) {
   workplace_infected <- state_[i_WORKING_AGE, i_Is, -i_NOT_WORKING, ] +
     state_[i_WORKING_AGE, i_Ia, -i_NOT_WORKING, ] * epsilon
   # NOTE: re-assigning `workplace_infected`
-  workplace_infected <- (cmw * workplace_infected +
-    cm_ww %*% workplace_infected) /
-    colSums(state_[i_WORKING_AGE, i_EPI_COMPARTMENTS, -i_NOT_WORKING, ])
+  workplace_infected <- cmw * workplace_infected
   # reset any NaNs to 0; NaNs come from zero division as vaxxed are initially 0s
   workplace_infected[is.nan(workplace_infected)] <- 0.0
 

--- a/R/reff_calculation.R
+++ b/R/reff_calculation.R
@@ -21,13 +21,12 @@ r_eff <- function(r0, state, cm) {
   # NOTE: assumes state is a 4D array, and
   # cm is a 2D contact matrix with eigenvalue = 1.0
   # NOTE: reduced susceptibility for vaccinated!
-  p_susc <- rowSums(
-    state[, i_S, , i_UNVACCINATED_STRATUM] +
-      0.5 * state[, i_S, , i_VACCINATED_STRATUM]
-  ) / rowSums(state[, i_EPI_COMPARTMENTS, , -i_NEW_VAX_STRATUM])
-  cm_eff <- cm %*% diag(p_susc)
+  p_susc <- sum(
+    state[, i_S, i_UNVACCINATED_STRATUM] +
+      0.5 * state[, i_S, i_VACCINATED_STRATUM]
+  ) / sum(state[, i_EPI_COMPARTMENTS, -i_NEW_VAX_STRATUM])
 
-  r0 * max(Re(eigen(cm_eff)$values))
+  r0 * p_susc
 }
 
 #' @title Calculate total hospitalisations
@@ -38,5 +37,5 @@ r_eff <- function(r0, state, cm) {
 get_hospitalisations <- function(state) {
   # NOTE: assumes state is a 4D array; not checked as this is internal
   # remove the new vaccinations stratum from sum
-  sum(state[, i_H, , -i_NEW_VAX_STRATUM])
+  sum(state[, i_H, -i_NEW_VAX_STRATUM])
 }

--- a/R/social_distancing.R
+++ b/R/social_distancing.R
@@ -9,7 +9,7 @@
 #'
 #' @param new_deaths The number of new deaths at time `t`.
 #' @param rate The proportional reduction of social contacts due to each
-#' additional death. Defaults to 0.01, or a 1% decrease for each additional
+#' additional death. Defaults to 0.01, or a 0.1% decrease for each additional
 #' death.
 #' @param lower_limit The lower limit to which social contacts can be reduced.
 #' Defaults to 0.2, which is equivalent to a greater than a 50% reduction in
@@ -19,7 +19,7 @@
 #' coefficient.
 #' @keywords internal
 get_distancing_coefficient <- function(
-    new_deaths, rate = 0.01, lower_limit = 0.2) {
+    new_deaths, rate = 0.001, lower_limit = 0.2) {
   # NOTE: no input checks on this internal function
   (1 - rate)^new_deaths * (1 - lower_limit) + lower_limit
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -8,6 +8,8 @@ EPPI
 Forchini
 GH
 GVA
+Jameel
+Latif
 ODEs
 ORCID
 Pianella

--- a/man/daedalus-package.Rd
+++ b/man/daedalus-package.Rd
@@ -3,14 +3,15 @@
 \docType{package}
 \name{daedalus-package}
 \alias{daedalus-package}
-\title{daedalus: Model health, social, and economic costs of a pandemic using _DAEDALUS_}
+\title{daedalus: Model health, social, and economic costs of a pandemic using DAEDALUS}
 \description{
-Model the health, social, and economic costs of directly transmitted respiratory virus pandemics, under different scenarios of preparedness and reactive interventions, using the _DAEDALUS_ integrated health-economics model adapted from Haw et al. (2022) <doi.org/10.1038/s43588-022-00233-0>.
+Model the health, education, and economic costs of directly transmitted respiratory virus pandemics, under different scenarios of prior vaccine investment and reactive interventions, using the _DAEDALUS_ integrated health-economics model adapted from Haw et al. (2022) <doi.org/10.1038/s43588-022-00233-0>.
 }
 \seealso{
 Useful links:
 \itemize{
   \item \url{https://github.com/j-idea/daedalus}
+  \item \url{https://jameel-institute.github.io/daedalus/}
   \item Report bugs at \url{https://github.com/j-idea/daedalus/issues}
 }
 
@@ -18,9 +19,20 @@ Useful links:
 \author{
 \strong{Maintainer}: Pratik Gupte \email{p.gupte24@imperial.ac.uk} (\href{https://orcid.org/0000-0001-5294-7819}{ORCID})
 
+Authors:
+\itemize{
+  \item Patrick Doohan (\href{https://orcid.org/0000-0001-8076-1106}{ORCID})
+  \item Robert Johnson (\href{https://orcid.org/0000-0002-7365-0042}{ORCID})
+  \item Rich FitzJohn (\href{https://orcid.org/0000-0001-8888-3837}{ORCID})
+  \item Emma Russell
+  \item David Mears
+  \item Katharina Hauck (\href{https://orcid.org/0000-0003-3138-4169}{ORCID})
+}
+
 Other contributors:
 \itemize{
-  \item Imperial College of Science, Technology and Medicine [copyright holder]
+  \item Abdul Latif Jameel Institute for Disease and Emergency Analytics [funder]
+  \item Imperial College of Science, Technology and Medicine [copyright holder, funder]
 }
 
 }

--- a/man/get_distancing_coefficient.Rd
+++ b/man/get_distancing_coefficient.Rd
@@ -4,13 +4,13 @@
 \alias{get_distancing_coefficient}
 \title{Coefficient to scale transmission by public concern about the pandemic}
 \usage{
-get_distancing_coefficient(new_deaths, rate = 0.01, lower_limit = 0.2)
+get_distancing_coefficient(new_deaths, rate = 0.001, lower_limit = 0.2)
 }
 \arguments{
 \item{new_deaths}{The number of new deaths at time \code{t}.}
 
 \item{rate}{The proportional reduction of social contacts due to each
-additional death. Defaults to 0.01, or a 1\% decrease for each additional
+additional death. Defaults to 0.01, or a 0.1\% decrease for each additional
 death.}
 
 \item{lower_limit}{The lower limit to which social contacts can be reduced.

--- a/man/make_initial_state.Rd
+++ b/man/make_initial_state.Rd
@@ -24,11 +24,17 @@ symptomatic individuals in each age group and economic sector.
 Defaults to \code{1e-6} and \code{0.0} respectively.}
 }
 \value{
-An array with as many dimensions as \code{N_ECON_STRATA} (currently, 46)
-with each layer giving the proportion of individuals of each group in each
-epidemiological compartment.
+An array with as many dimensions as \code{N_VACCINE_DATA_GROUPS}
+(currently, 3); rows specify the age and economic groups, columns specify the
+epidemiological compartments (including new infections and hospitalisations),
+and array layers hold information on vaccination status (including new
+vaccinations).
 }
 \description{
-Function to prepare the model initial state.
+Function to prepare the model initial state. Assumes that
+1 in every million individuals is initially infected, and that 60\% are
+asymptomatic infections. This does not affect the actual probability of
+asymptomatic infections in the simulation, which is a property of a
+\verb{<daedalus_infection>}.
 }
 \keyword{internal}

--- a/man/model_constants.Rd
+++ b/man/model_constants.Rd
@@ -4,11 +4,13 @@
 \name{model_constants}
 \alias{model_constants}
 \alias{N_AGE_GROUPS}
+\alias{i_AGE_GROUPS}
 \alias{N_VACCINE_STRATA}
 \alias{N_VACCINE_DATA_GROUPS}
 \alias{AGE_GROUPS}
 \alias{i_WORKING_AGE}
 \alias{N_ECON_SECTORS}
+\alias{i_ECON_SECTORS}
 \alias{i_EDUCATION_SECTOR}
 \alias{N_ECON_STRATA}
 \alias{i_NOT_WORKING}
@@ -25,6 +27,8 @@
 \format{
 An object of class \code{integer} of length 1.
 
+An object of class \code{integer} of length 4.
+
 An object of class \code{integer} of length 1.
 
 An object of class \code{integer} of length 1.
@@ -34,6 +38,8 @@ An object of class \code{character} of length 4.
 An object of class \code{integer} of length 1.
 
 An object of class \code{integer} of length 1.
+
+An object of class \code{integer} of length 45.
 
 An object of class \code{integer} of length 1.
 
@@ -62,6 +68,8 @@ An object of class \code{integer} of length 1.
 \usage{
 N_AGE_GROUPS
 
+i_AGE_GROUPS
+
 N_VACCINE_STRATA
 
 N_VACCINE_DATA_GROUPS
@@ -71,6 +79,8 @@ AGE_GROUPS
 i_WORKING_AGE
 
 N_ECON_SECTORS
+
+i_ECON_SECTORS
 
 i_EDUCATION_SECTOR
 

--- a/tests/testthat/test-closures.R
+++ b/tests/testthat/test-closures.R
@@ -142,7 +142,7 @@ test_that("Closures: correct logging of time limits", {
         data <- daedalus(
           "United States", "influenza_1957",
           initial_state_manual = list(
-            p_infectious = 0.9
+            p_infectious = 0.9999
           ),
           response_strategy = "elimination",
           response_time = x,

--- a/tests/testthat/test-daedalus.R
+++ b/tests/testthat/test-daedalus.R
@@ -30,10 +30,12 @@ test_that("daedalus: basic expectations", {
     c(
       "time", "age_group", "compartment", "econ_sector",
       "vaccine_group", "value"
-    )
+    ),
+    ignore.order = TRUE
   )
-  expect_type(
-    data[["time"]], "integer"
+  checkmate::expect_numeric(
+    data[["time"]],
+    lower = 1, upper = time_end
   )
   expect_type(
     data[["age_group"]], "character"


### PR DESCRIPTION
This PR updates the state variable in `daedalus()` to substantially reduce the number of compartments; all empty compartments have been removed. This improves the speed of model runs as there are fewer derivatives to calculate.

1. State variable is a 3D array with the dimensions: `c(49, 9, 3)`. The working-age economic sectors are added on as rows after the age-groups. Epidemiological compartments are unchanged. The third dimension holds data on vaccination status, including new vaccinations.

2. Helper functions are updated to support the new state dimensions.

3. $R_t$ calculation in `r_eff()` has been simplified to the proportional susceptible times $R_0$, pending a more accurate calculation.

4. The internal helper function `prepare_output()` has been refactored to avoid use of `base::array2DF()` to remove the dependency on newer versions of R.

5. Removes unused between-sector contacts in force-of-infection calculations.

6. Moves some contact scaling to the parameter preparation stage to reduce operations during the model run.

7. Correctly sums the total number of infectious individuals in the community; previously, the implementation resulted in segregation by economic sector.