### PR TITLE
Add parameter uncertainty vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,8 +43,7 @@ Suggests:
     rmarkdown,
     scales,
     spelling,
-    testthat (>= 3.0.0),
-    withr
+    testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr
 Config/Needs/website: jameel-institute/jameelinst.rpkg.theme

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Suggests:
     ggplot2,
     knitr,
     rmarkdown,
+    scales,
     spelling,
     testthat (>= 3.0.0),
     withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: daedalus
 Title: Model health, social, and economic costs of a pandemic using
     DAEDALUS
-Version: 0.0.23
+Version: 0.0.24
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,11 +37,13 @@ Imports:
     rlang
 Suggests:
     countrycode,
+    ggdist,
     ggplot2,
     knitr,
     rmarkdown,
     spelling,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 VignetteBuilder: 
     knitr
 Config/Needs/website: jameel-institute/jameelinst.rpkg.theme

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,9 +24,9 @@ Description: Model the health, education, and economic costs of directly
     _DAEDALUS_ integrated health-economics model adapted from Haw et al.
     (2022) <doi.org/10.1038/s43588-022-00233-0>.
 License: MIT + file LICENSE
-URL: https://github.com/j-idea/daedalus,
+URL: https://github.com/jameel-institute/daedalus,
     https://jameel-institute.github.io/daedalus/
-BugReports: https://github.com/j-idea/daedalus/issues
+BugReports: https://github.com/jameel-institute/daedalus/issues
 Depends: 
     R (>= 2.10)
 Imports: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus 0.0.24
+
+This patch version adds a vignette on exploring the effect of parameter uncertainty on overall pandemic costs, and updates other vignettes and improves documentation.
+
 # daedalus 0.0.23
 
 This patch corrects epidemic dynamics:

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,8 +19,8 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
-[![R build status](https://github.com/j-idea/daedalus/workflows/R-CMD-check/badge.svg)](https://github.com/j-idea/daedalus/actions/workflows/R-CMD-check.yaml)
-[![Codecov test coverage](https://codecov.io/gh/j-idea/daedalus/branch/main/graph/badge.svg)](https://app.codecov.io/gh/j-idea/daedalus?branch=main)
+[![R build status](https://github.com/jameel-institute/daedalus/workflows/R-CMD-check/badge.svg)](https://github.com/jameel-institute/daedalus/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/jameel-institute/daedalus/branch/main/graph/badge.svg)](https://app.codecov.io/gh/jameel-institute/daedalus?branch=main)
 [![CRAN status](https://www.r-pkg.org/badges/version/daedalus)](https://CRAN.R-project.org/package=daedalus)
 <!-- badges: end -->
 
@@ -30,9 +30,9 @@ _daedalus_ implements the integrated epidemiological and economic model in @haw2
 
 You can install the development version of daedalus from [GitHub](https://github.com/) using the _remotes_ package.
 
-``` r
-# install.packages("remotes")
-remotes::install_github("j-idea/daedalus", upgrade = FALSE)
+```r
+# install.packages("pak")
+pak::pak("jameel-institute/daedalus", upgrade = FALSE)
 ```
 
 ## Quick start

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,11 +28,19 @@ _daedalus_ implements the integrated epidemiological and economic model in @haw2
 
 ## Installation
 
-You can install the development version of daedalus from [GitHub](https://github.com/) using the _remotes_ package.
+You can install the development version of daedalus from this repository using the _pak_ package, or from the Jameel Institute R-universe.
 
 ```r
 # install.packages("pak")
 pak::pak("jameel-institute/daedalus", upgrade = FALSE)
+
+# installation from R-universe
+install.packages(
+  "daedalus", 
+  repos = c(
+    "https://jameel-institute.r-universe.dev", "https://cloud.r-project.org"
+  )
+)
 ```
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ yet, or the repository is only intended to be a limited example, demo,
 or
 proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
 [![R build
-status](https://github.com/j-idea/daedalus/workflows/R-CMD-check/badge.svg)](https://github.com/j-idea/daedalus/actions/workflows/R-CMD-check.yaml)
+status](https://github.com/jameel-institute/daedalus/workflows/R-CMD-check/badge.svg)](https://github.com/jameel-institute/daedalus/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
-coverage](https://codecov.io/gh/j-idea/daedalus/branch/main/graph/badge.svg)](https://app.codecov.io/gh/j-idea/daedalus?branch=main)
+coverage](https://codecov.io/gh/jameel-institute/daedalus/branch/main/graph/badge.svg)](https://app.codecov.io/gh/jameel-institute/daedalus?branch=main)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/daedalus)](https://CRAN.R-project.org/package=daedalus)
 <!-- badges: end -->
@@ -26,8 +26,8 @@ You can install the development version of daedalus from
 [GitHub](https://github.com/) using the *remotes* package.
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("j-idea/daedalus", upgrade = FALSE)
+# install.packages("pak")
+pak::pak("jameel-institute/daedalus", upgrade = FALSE)
 ```
 
 ## Quick start
@@ -47,12 +47,12 @@ data <- daedalus("Canada", "influenza_1918")
 
 # get pandemic costs as a total in million dollars
 get_costs(data, "total")
-#> [1] 490778
+#> [1] 1621184
 
 # disaggregate total for economic, education, and health costs
 get_costs(data, "domain")
-#>   economic  education life_years 
-#>  32762.859   2438.326 455576.772
+#>    economic   education  life_years 
+#>   33680.950    2201.333 1585301.497
 ```
 
 Users can select infection parameters from among seven epidemics caused
@@ -77,9 +77,10 @@ preparedness](https://github.com/robj411/p2_drivers).
 
 ## References
 
-<div id="refs" class="references hanging-indent">
+<div id="refs" class="references csl-bib-body hanging-indent"
+entry-spacing="0">
 
-<div id="ref-haw2022">
+<div id="ref-haw2022" class="csl-entry">
 
 Haw, David J., Giovanni Forchini, Patrick Doohan, Paula Christen, Matteo
 Pianella, Robert Johnson, Sumali Bajaj, et al. 2022. “Optimizing Social

--- a/README.md
+++ b/README.md
@@ -22,12 +22,20 @@ in Haw et al. ([2022](#ref-haw2022)).
 
 ## Installation
 
-You can install the development version of daedalus from
-[GitHub](https://github.com/) using the *remotes* package.
+You can install the development version of daedalus from this repository
+using the *pak* package, or from the Jameel Institute R-universe.
 
 ``` r
 # install.packages("pak")
 pak::pak("jameel-institute/daedalus", upgrade = FALSE)
+
+# installation from R-universe
+install.packages(
+  "daedalus", 
+  repos = c(
+    "https://jameel-institute.r-universe.dev", "https://cloud.r-project.org"
+  )
+)
 ```
 
 ## Quick start

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -23,6 +23,7 @@ asymp
 doi
 econ
 erroring
+ggdist
 offs
 org
 rootfinding

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -23,9 +23,11 @@ asymp
 doi
 econ
 erroring
+furrr
 ggdist
 offs
 org
+pak
 rootfinding
 started’
 symp

--- a/man/daedalus-package.Rd
+++ b/man/daedalus-package.Rd
@@ -10,9 +10,9 @@ Model the health, education, and economic costs of directly transmitted respirat
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/j-idea/daedalus}
+  \item \url{https://github.com/jameel-institute/daedalus}
   \item \url{https://jameel-institute.github.io/daedalus/}
-  \item Report bugs at \url{https://github.com/j-idea/daedalus/issues}
+  \item Report bugs at \url{https://github.com/jameel-institute/daedalus/issues}
 }
 
 }

--- a/vignettes/parameter_uncertainty.Rmd
+++ b/vignettes/parameter_uncertainty.Rmd
@@ -1,0 +1,124 @@
+---
+title: "Exploring uncertainty in pandemic costs due to parameter uncertainty"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Exploring uncertainty in pandemic costs due to parameter uncertainty}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+This vignette shows how to explore the effect of model parameter uncertainty on epidemic costs using _daedalus_.
+
+Here we explore the effect of uncertainty in $R_0$, which is a common use case in the initial stages of a novel pandemic when estimates of $R_0$ are less robust.
+
+We shall model uncertainty in a scenario of a SARS-2004 like infection outbreak in a country chosen at random, Norway.
+
+We focus on infection parameter uncertainty, but a similar approach can be applied to country characteristics.
+
+```{r setup}
+# load {daedalus} and helper packages
+library(daedalus)
+
+library(data.table)
+library(ggplot2)
+library(ggdist)
+```
+
+## General approach
+
+The general approach is:
+
+- Create multiple `<daedalus_infection>` objects with distinct values of parameters;
+
+- Run `daedalus()` on each distinct `<daedalus_infection>` object;
+
+- Get costs from each model output object.
+
+
+## Drawing parameters from a distribution
+
+First, we access the SARS 2004 $R_0$ provided in _daedalus_, and using this as a mean we draw 100 samples from a normal distribution with a standard deviation of 0.1.
+
+```{r get_sars_r0}
+# get SARS-1 R0
+sars_2004 <- daedalus_infection("sars_cov_1")
+sars_2004_r0 <- get_data(sars_2004, "r0")
+
+# draw samples from a normal distribution
+r0_samples <- withr::with_seed(
+  1,
+  rnorm(100, sars_2004_r0, sd = 0.1)
+)
+```
+
+## Create infection objects
+
+Next we create `<daedalus_infection>` objects to hold the $R_0$ values.
+
+**Note that** future versions of _daedalus_ will include better support for parameter uncertainty, such as that provided by the [_distributional_ package](https://cran.r-project.org/package=distributional).
+
+```{r make_inf_objs}
+# make a list of infection objects
+infection_list <- lapply(
+  r0_samples, function(x) daedalus_infection("sars_cov_1", r0 = x)
+)
+
+# View an infection object
+infection_list[[1]]
+```
+
+## Run DAEDALUS model for each infection object
+
+We run the model for Norway with each infection object, representing different values of $R_0$.
+
+We assume that there is no vaccine investment in advance of the outbreak. Vaccination with a pathogen specific vaccine is thus assumed to begin 1 year after the epidemic start date, similar to the situation for Covid-19.
+
+We also assume for this example that this outbreak is unmitigated and allowed to become an epidemic.
+
+The model runs for 600 days or a little over 1.5 years.
+
+**Note that** running `daedalus()` iteratively may take some time, as the function checks the inputs and internally prepares parameters each time, as well as preparing the output data. Future package versions aim to streamline these steps and provide a stripped down version of the function optimised for scenario modelling for parameter fitting or with parameter uncertainty.
+
+```{r uncertainty_run_model}
+# run daedalus()
+output_list <- lapply(
+  infection_list, daedalus,
+  country = "Norway"
+)
+```
+
+## Get epidemic costs
+
+We can get the total epidemic costs --- a combination of life years lost, educational losses leading to lost future earnings, and economic losses due to worker illness --- using the helper function `get_costs()` and passing the option `summarise_as = "total"`.
+
+```{r}
+# get costs
+costs <- vapply(
+  output_list, get_costs, numeric(1), "total"
+)
+```
+
+We can plot the total costs to view the distribution using the [_ggdist_ package](https://cran.r-project.org/package=ggdist) to visualise the distribution.
+
+```{r plot_total_costs_dist, echo=FALSE}
+ggplot() +
+  stat_histinterval(
+    aes(costs),
+    fill = "steelblue"
+  ) +
+  scale_x_continuous(
+    labels = scales::comma_format()
+  ) +
+  theme_tidybayes() +
+  labs(
+    x = "Overall epidemic cost (million $)",
+    y = "Density"
+  )
+```

--- a/vignettes/parameter_uncertainty.Rmd
+++ b/vignettes/parameter_uncertainty.Rmd
@@ -12,6 +12,9 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+
+# set seed for local reproducibility
+set.seed(1)
 ```
 
 This vignette shows how to explore the effect of model parameter uncertainty on epidemic costs using _daedalus_.
@@ -52,10 +55,7 @@ sars_2004 <- daedalus_infection("sars_cov_1")
 sars_2004_r0 <- get_data(sars_2004, "r0")
 
 # draw samples from a normal distribution
-r0_samples <- withr::with_seed(
-  1,
-  rnorm(100, sars_2004_r0, sd = 0.1)
-)
+r0_samples <- rnorm(100, sars_2004_r0, sd = 0.1)
 ```
 
 ## Create infection objects
@@ -86,6 +86,8 @@ The model runs for 600 days or a little over 1.5 years.
 
 **Note that** running `daedalus()` iteratively may take some time, as the function checks the inputs and internally prepares parameters each time, as well as preparing the output data. Future package versions aim to streamline these steps and provide a stripped down version of the function optimised for scenario modelling for parameter fitting or with parameter uncertainty.
 
+Users can run the model iteratively over the $R_0$ samples in parallel using frameworks such as [the _furrr_ package](https://cran.r-project.org/package=furrr).
+
 ```{r uncertainty_run_model}
 # run daedalus()
 output_list <- lapply(
@@ -107,7 +109,9 @@ costs <- vapply(
 
 We can plot the total costs to view the distribution using the [_ggdist_ package](https://cran.r-project.org/package=ggdist) to visualise the distribution.
 
-```{r plot_total_costs_dist, echo=FALSE}
+```{r plot_total_costs_dist}
+# Use {ggplot2} to visualise the output
+# `stat_histinterval()` is from {ggdist}
 ggplot() +
   stat_histinterval(
     aes(costs),


### PR DESCRIPTION
This PR adds a vignette showing how to use {daedalus} to model the effect of parameter uncertainty on pandemic cost projections.