### PR TITLE
Bump to v0.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: daedalus
 Title: Model health, social, and economic costs of a pandemic using
     DAEDALUS
-Version: 0.0.24
+Version: 0.1.0
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus 0.1.0
+
+This is a minor version release of {daedalus} for use in the IDM conference in 2024.
+
 # daedalus 0.0.24
 
 This patch version adds a vignette on exploring the effect of parameter uncertainty on overall pandemic costs, and updates other vignettes and improves documentation.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -9,6 +9,7 @@ Forchini
 GH
 GNI
 GVA
+IDM
 IFR
 Jameel
 Latif


### PR DESCRIPTION
This PR updates the version to the first minor version, 0.1.0. There's no specific reason to bump it to a minor version, other than that this is a sort of milestone that will be useful as a reference point for future work. Happy to work out a versioning policy for future use.