### PR TITLE
Remove separate infection pathways for vaccination groups

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -8,6 +8,10 @@ on:
 
 name: R-CMD-check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -11,6 +11,10 @@ on:
 
 name: pkgdown
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -8,6 +8,10 @@ on:
 
 name: test-coverage
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: daedalus
 Title: Model health, social, and economic costs of a pandemic using
     DAEDALUS
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@ This patch version makes changes to how vaccine groups are modelled in {daedalus
 
 6. Reduced use of {rlang} for environment access and modification.
 
+7. Updates GitHub Actions workflows to cancel concurrent runs.
+
 # daedalus 0.1.0
 
 This is a minor version release of {daedalus} for use in the IDM conference in 2024.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# daedalus 0.1.1
+
+This patch version makes changes to how vaccine groups are modelled in {daedalus}. The model trades explicit tracking of infection pathways of different vaccine groups for a gain in performance.
+
+1. Vaccine groups now share a single infection pathway, cutting the number of model compartments to 539 (49 age and economic groups $\times$ 11 epi and data compartments) from 1323. This improves performance in most cases by about 3x.
+
+2. The state variable adds two compartments, one for vaccinated individuals who have a lower susceptibility to infection ($\tau \beta$; $\tau = 0.5$), and one for the number of new vaccinations per timestep.
+
+3. Individuals in both susceptible and recovered compartments are considered eligible for vaccination. Vaccinated individuals transition at the rate $\psi$ into the susceptible compartment, but not into the recovered compartment. The vaccine-derived protection and waning dynamics need more work to ensure they have realistic transition rates, and/or to make transition rates independent and flexible.
+
+4. The helper functions `values_to_state()`, `r_eff()`, `get_hospitalisations()`, `make_initial_state()`, `prepare_output()`, and `get_daily_vaccinations()` have been updated to reflect the reduced state size.
+
+5. Tests have been updated to reflect reduced state size.
+
+6. Reduced use of {rlang} for environment access and modification.
+
 # daedalus 0.1.0
 
 This is a minor version release of {daedalus} for use in the IDM conference in 2024.

--- a/R/class_vaccination.R
+++ b/R/class_vaccination.R
@@ -282,9 +282,9 @@ scale_nu <- function(state, nu, uptake_limit) {
   # NOTE: state must be a 4D array with only vaccinated and unvaccinated layers
   # in dim 4
   total <- sum(
-    state[, i_EPI_COMPARTMENTS, c(i_VACCINATED_STRATUM, i_UNVACCINATED_STRATUM)]
+    state[, i_EPI_COMPARTMENTS]
   )
-  total_vaccinated <- sum(state[, i_EPI_COMPARTMENTS, i_VACCINATED_STRATUM])
+  total_vaccinated <- sum(state[, i_V])
   prop_vaccinated <- total_vaccinated / total
 
   # NOTE: simplified scaling works only for uniform rates and start times

--- a/R/closure.R
+++ b/R/closure.R
@@ -21,21 +21,16 @@ make_response_threshold_event <- function(response_threshold) {
     rt <- r_eff(state, parameters)
 
     # NOTE: to ensure only first hosp threshold crossing is logged
-    is_hosp_switch_on <- rlang::env_get(parameters[["mutables"]], "hosp_switch")
+    is_hosp_switch_on <- parameters[["mutables"]]$hosp_switch
 
     if (time != parameters[["min_time"]] && !is_hosp_switch_on) {
-      rlang::env_poke(
-        parameters[["mutables"]], "hosp_switch", TRUE
-      )
+      parameters[["mutables"]]$hosp_switch <- TRUE
 
       # NOTE: trigger response and log closure start time only if
       # epidemic is growing
       if (rt >= 1.0) {
-        rlang::env_bind(
-          parameters[["mutables"]],
-          switch = TRUE,
-          closure_time_start = time
-        )
+        parameters[["mutables"]]$switch <- TRUE
+        parameters[["mutables"]]$closure_time_start <- time
       }
     }
     as.numeric(state)
@@ -62,14 +57,11 @@ make_rt_end_event <- function() {
 
   event_function <- function(time, state, parameters) {
     # NOTE: log the FIRST time Rt < 1.0 as closure time end
-    is_switch_on <- rlang::env_get(parameters[["mutables"]], "switch")
+    is_switch_on <- parameters[["mutables"]]$switch
     # prevent flipping switch when checkEventFunc runs
     if (time != parameters[["min_time"]] && is_switch_on) {
-      rlang::env_bind(
-        parameters[["mutables"]],
-        switch = FALSE,
-        closure_time_end = time
-      )
+      parameters[["mutables"]]$switch <- FALSE
+      parameters[["mutables"]]$closure_time_end <- time
     }
 
     # switch execess mortality on or off independent of closure status
@@ -79,13 +71,9 @@ make_rt_end_event <- function() {
       total_hosp <- get_hospitalisations(state)
 
       if (total_hosp > parameters[["hospital_capacity"]]) {
-        rlang::env_poke(
-          parameters[["mutables"]], "hosp_switch", TRUE
-        )
+        parameters[["mutables"]]$hosp_switch <- TRUE
       } else {
-        rlang::env_poke(
-          parameters[["mutables"]], "hosp_switch", FALSE
-        )
+        parameters[["mutables"]]$hosp_switch <- FALSE
       }
     }
 

--- a/R/constants.R
+++ b/R/constants.R
@@ -49,14 +49,6 @@ i_AGE_GROUPS <- seq_len(N_AGE_GROUPS)
 
 #' @name model_constants
 #' @keywords model_constant
-N_VACCINE_STRATA <- 2L
-
-#' @name model_constants
-#' @keywords model_constant
-N_VACCINE_DATA_GROUPS <- 3L
-
-#' @name model_constants
-#' @keywords model_constant
 AGE_GROUPS <- c("0-4", "5-19", "20-65", "65+")
 
 #' @name model_constants
@@ -107,20 +99,8 @@ DIM_ECON_SECTORS <- 3L
 DIM_VACCINE_STRATA <- 4L
 
 #' @name model_constants
-i_UNVACCINATED_STRATUM <- 1L
-
-#' @name model_constants
-i_VACCINATED_STRATUM <- 2L
-
-#' @name model_constants
-i_NEW_VAX_STRATUM <- 3L
-
-#' @name model_constants
-VACCINE_GROUPS <- c("unvaccinated", "vaccinated", "new_vaccinations")
-
-#' @name model_constants
 #' @keywords model_constant
-N_OUTPUT_COLS <- 6L
+N_OUTPUT_COLS <- 5L
 
 #' @title Epidemiological compartments and indices
 #' @description Names and indices for the epidemiological compartments used in
@@ -147,25 +127,25 @@ N_OUTPUT_COLS <- 6L
 #' @keywords epi_constant
 COMPARTMENTS <- c(
   "susceptible", "exposed", "infect_symp", "infect_asymp",
-  "hospitalised", "recovered", "dead",
-  "new_infections", "new_hosp"
+  "hospitalised", "recovered", "dead", "vaccinated",
+  "new_infections", "new_hosp", "new_vax"
 )
 
 #' @name epi_constants
 #' @keywords epi_constant
-N_MODEL_COMPARTMENTS <- 9L
+N_MODEL_COMPARTMENTS <- 11L
 
 #' @name epi_constants
-N_EPI_COMPARTMENTS <- 7L
+N_EPI_COMPARTMENTS <- 8L
 
 #' @name epi_constants
-N_DATA_COMPARTMENTS <- 2L
+N_DATA_COMPARTMENTS <- 3L
 
 #' @name epi_constants
 i_EPI_COMPARTMENTS <- seq.int(N_EPI_COMPARTMENTS)
 
 #' @name epi_constants
-i_DATA_COMPARTMENTS <- c(8L, 9L)
+i_DATA_COMPARTMENTS <- c(9L, 10L, 11L)
 
 #' @name epi_constants
 #' @keywords epi_constant
@@ -190,13 +170,16 @@ i_R <- 6L
 i_D <- 7L
 
 #' @name epi_constants
-i_dE <- 8L # new infections
+i_V <- 8L
 
 #' @name epi_constants
-i_dH <- 9L # new hospitalisations
+i_dE <- 9L # new infections
 
 #' @name epi_constants
-i_dD <- 10L # new deaths
+i_dH <- 10L # new hospitalisations
+
+#' @name epi_constants
+i_dV <- 11L # new deaths
 
 #' @name epi_constants
 N_INFECTION_SUBSYSTEM <- 3L # compartments in the infectious subsystem
@@ -212,7 +195,7 @@ SUMMARY_MEASURES <- c(
 )
 
 #' @name summary_constants
-SUMMARY_GROUPS <- c("age_group", "vaccine_group", "econ_sector")
+SUMMARY_GROUPS <- c("age_group", "econ_sector")
 
 #' Economic constants used in DAEDALUS
 #'

--- a/R/model_helpers.R
+++ b/R/model_helpers.R
@@ -15,7 +15,7 @@
 #' @keywords internal
 make_initial_state <- function(
     country,
-    initial_state_manual) {
+    initial_state_manual = list()) {
   # NOTE: country checked in daedalus()
   initial_infect_state <- list(
     p_infectious = 1e-6,
@@ -53,8 +53,8 @@ make_initial_state <- function(
     S = 1.0 - p_infectious, E = 0.0,
     Is = p_infectious * (1.0 - p_asymptomatic),
     Ia = p_infectious * p_asymptomatic,
-    H = 0.0, R = 0.0, D = 0.0,
-    dE = 0.0, dH = 0.0
+    H = 0.0, R = 0.0, D = 0.0, V = 0.0,
+    dE = 0.0, dH = 0.0, dV = 0.0
   )
 
   # build for all age groups and economic sectors (working age only)
@@ -77,12 +77,6 @@ make_initial_state <- function(
 
   initial_state[(N_AGE_GROUPS + 1):nrow(initial_state), ] <-
     initial_state[(N_AGE_GROUPS + 1):nrow(initial_state), ] * sector_workforce
-
-  # add strata for vaccination groups and set to zero
-  initial_state <- array(
-    initial_state, c(dim(initial_state), N_VACCINE_DATA_GROUPS)
-  )
-  initial_state[, , -i_UNVACCINATED_STRATUM] <- 0
 
   initial_state
 }
@@ -148,7 +142,7 @@ get_closure_info <- function(mutables) {
 #' @keywords internal
 values_to_state <- function(x) {
   dim(x) <- c(
-    N_AGE_GROUPS + N_ECON_SECTORS, N_MODEL_COMPARTMENTS, N_VACCINE_DATA_GROUPS
+    N_AGE_GROUPS + N_ECON_SECTORS, N_MODEL_COMPARTMENTS
   )
 
   x

--- a/R/output_helpers.R
+++ b/R/output_helpers.R
@@ -21,9 +21,7 @@
 #' @param groups An optional character vector of grouping variables that
 #' correspond to model strata. Defaults to `NULL` which gives incidence across
 #' the whole population. Allowed groups correspond to modelled strata:
-#' `"age_group"`, `"vaccine_group"`, and `"econ_sector"`.
-#'
-#' `get_daily_vaccinations()` only accepts "`age_group`" and `"econ_sector"`.
+#' `"age_group"` and `"econ_sector"`.
 #'
 #' @return A `<data.frame>` in long format, with one entry per
 #' model timestep, measure, and group chosen.
@@ -221,12 +219,8 @@ get_new_vaccinations <- function(data, groups = NULL) {
     data <- get_data(data)
   }
 
-  # NOTE: allowed groups are different from SUMMARY_GROUPS as `vaccine_group`
-  # is not allowed
-  allowed_groups <- setdiff(SUMMARY_GROUPS, "vaccine_group")
-
   is_good_groups <- checkmate::test_subset(
-    groups, allowed_groups
+    groups, SUMMARY_GROUPS
   )
   if (!is_good_groups) {
     cli::cli_abort(
@@ -238,7 +232,7 @@ get_new_vaccinations <- function(data, groups = NULL) {
     )
   }
 
-  dt_new <- data[data$vaccine_group == "new_vaccinations", ]
+  dt_new <- data[data$compartment == "new_vax", ]
   data.table::setDT(dt_new)
 
   dt_new <- dt_new[, list(value = sum(value)), by = c("time", groups)]

--- a/R/prepare_output.R
+++ b/R/prepare_output.R
@@ -25,7 +25,6 @@ prepare_output <- function(output) {
     COMPARTMENTS,
     each = (N_AGE_GROUPS + N_ECON_SECTORS) * n_times
   )
-  compartment_labels <- rep(compartment_labels, N_VACCINE_DATA_GROUPS)
 
   # economic sector labels including non-working
   econ_sectors <- sprintf("sector_%02i", seq.int(N_ECON_SECTORS))
@@ -34,7 +33,7 @@ prepare_output <- function(output) {
     each = n_times
   )
   econ_labels <- rep(
-    econ_labels, N_MODEL_COMPARTMENTS * N_VACCINE_DATA_GROUPS
+    econ_labels, N_MODEL_COMPARTMENTS
   )
 
   # age group labels
@@ -42,12 +41,8 @@ prepare_output <- function(output) {
     c(AGE_GROUPS, rep(AGE_GROUPS[i_WORKING_AGE], N_ECON_SECTORS)),
     each = n_times
   )
-  age_labels <- rep(age_labels, N_MODEL_COMPARTMENTS * N_VACCINE_DATA_GROUPS)
-
-  # vaccine group labels
-  vaccine_labels <- rep(
-    VACCINE_GROUPS,
-    each = (N_AGE_GROUPS + N_ECON_SECTORS) * N_MODEL_COMPARTMENTS * n_times
+  age_labels <- rep(
+    age_labels, N_MODEL_COMPARTMENTS #* N_VACCINE_DATA_GROUPS
   )
 
   # make data.frame, then data.table, pivot longer and assign labels
@@ -55,21 +50,14 @@ prepare_output <- function(output) {
   data.table::setDT(data)
   data <- data.table::melt(data, id.vars = "time")
   data[, c(
-    "age_group", "econ_sector", "vaccine_group",
-    "compartment"
+    "age_group", "econ_sector", "compartment"
   ) := list(
-    age_labels, econ_labels, vaccine_labels,
-    compartment_labels
+    age_labels, econ_labels, compartment_labels
   )]
   data$variable <- NULL
 
   # reset to DF and return data
   data.table::setDF(data)
 
-  # new vaccinations only in susceptible and recovered epi compartments
-  data <- data[
-    !(data$vaccine_group == "new_vaccinations" &
-      !data$compartment %in% c("susceptible", "recovered")),
-  ]
   data
 }

--- a/R/reff_calculation.R
+++ b/R/reff_calculation.R
@@ -19,8 +19,8 @@
 #' @keywords internal
 r_eff <- function(state, parameters) {
   # get number of susceptibles
-  susceptibles <- state[, i_S, i_UNVACCINATED_STRATUM] +
-    0.5 * state[, i_S, i_VACCINATED_STRATUM] # reduced for vaccinated
+  susceptibles <- state[, i_S] +
+    0.5 * state[, i_V] # reduced for vaccinated
   susceptibles[i_WORKING_AGE] <- susceptibles[i_WORKING_AGE] +
     sum(susceptibles[i_ECON_SECTORS])
   susceptibles <- susceptibles[i_AGE_GROUPS]
@@ -138,5 +138,5 @@ get_beta <- function(infection, country) {
 get_hospitalisations <- function(state) {
   # NOTE: assumes state is a 4D array; not checked as this is internal
   # remove the new vaccinations stratum from sum
-  sum(state[, i_H, -i_NEW_VAX_STRATUM])
+  sum(state[, i_H])
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -29,6 +29,7 @@ asymp
 doi
 econ
 edu
+epi
 erroring
 frac
 furrr
@@ -36,6 +37,7 @@ ggdist
 offs
 org
 pak
+rlang
 rootfinding
 specifc
 started’

--- a/man/epi_constants.Rd
+++ b/man/epi_constants.Rd
@@ -16,13 +16,14 @@
 \alias{i_H}
 \alias{i_R}
 \alias{i_D}
+\alias{i_V}
 \alias{i_dE}
 \alias{i_dH}
-\alias{i_dD}
+\alias{i_dV}
 \alias{N_INFECTION_SUBSYSTEM}
 \title{Epidemiological compartments and indices}
 \format{
-An object of class \code{character} of length 9.
+An object of class \code{character} of length 11.
 
 An object of class \code{integer} of length 1.
 
@@ -30,9 +31,11 @@ An object of class \code{integer} of length 1.
 
 An object of class \code{integer} of length 1.
 
-An object of class \code{integer} of length 7.
+An object of class \code{integer} of length 8.
 
-An object of class \code{integer} of length 2.
+An object of class \code{integer} of length 3.
+
+An object of class \code{integer} of length 1.
 
 An object of class \code{integer} of length 1.
 
@@ -83,11 +86,13 @@ i_R
 
 i_D
 
+i_V
+
 i_dE
 
 i_dH
 
-i_dD
+i_dV
 
 N_INFECTION_SUBSYSTEM
 }

--- a/man/epi_output_helpers.Rd
+++ b/man/epi_output_helpers.Rd
@@ -36,9 +36,7 @@ provides the number of daily vaccinations.}
 \item{groups}{An optional character vector of grouping variables that
 correspond to model strata. Defaults to \code{NULL} which gives incidence across
 the whole population. Allowed groups correspond to modelled strata:
-\code{"age_group"}, \code{"vaccine_group"}, and \code{"econ_sector"}.
-
-\code{get_daily_vaccinations()} only accepts "\code{age_group}" and \code{"econ_sector"}.}
+\code{"age_group"} and \code{"econ_sector"}.}
 }
 \value{
 A \verb{<data.frame>} in long format, with one entry per

--- a/man/make_initial_state.Rd
+++ b/man/make_initial_state.Rd
@@ -4,7 +4,7 @@
 \alias{make_initial_state}
 \title{Generate a default initial state for DAEDALUS}
 \usage{
-make_initial_state(country, initial_state_manual)
+make_initial_state(country, initial_state_manual = list())
 }
 \arguments{
 \item{country}{A country or territory object of class \verb{<daedalus_country>},

--- a/man/model_constants.Rd
+++ b/man/model_constants.Rd
@@ -5,8 +5,6 @@
 \alias{model_constants}
 \alias{N_AGE_GROUPS}
 \alias{i_AGE_GROUPS}
-\alias{N_VACCINE_STRATA}
-\alias{N_VACCINE_DATA_GROUPS}
 \alias{AGE_GROUPS}
 \alias{i_WORKING_AGE}
 \alias{i_SCHOOL_AGE}
@@ -19,20 +17,12 @@
 \alias{DIM_EPI_COMPARTMENTS}
 \alias{DIM_ECON_SECTORS}
 \alias{DIM_VACCINE_STRATA}
-\alias{i_UNVACCINATED_STRATUM}
-\alias{i_VACCINATED_STRATUM}
-\alias{i_NEW_VAX_STRATUM}
-\alias{VACCINE_GROUPS}
 \alias{N_OUTPUT_COLS}
 \title{DAEDALUS model constants}
 \format{
 An object of class \code{integer} of length 1.
 
 An object of class \code{integer} of length 4.
-
-An object of class \code{integer} of length 1.
-
-An object of class \code{integer} of length 1.
 
 An object of class \code{character} of length 4.
 
@@ -59,23 +49,11 @@ An object of class \code{integer} of length 1.
 An object of class \code{integer} of length 1.
 
 An object of class \code{integer} of length 1.
-
-An object of class \code{integer} of length 1.
-
-An object of class \code{integer} of length 1.
-
-An object of class \code{character} of length 3.
-
-An object of class \code{integer} of length 1.
 }
 \usage{
 N_AGE_GROUPS
 
 i_AGE_GROUPS
-
-N_VACCINE_STRATA
-
-N_VACCINE_DATA_GROUPS
 
 AGE_GROUPS
 
@@ -100,14 +78,6 @@ DIM_EPI_COMPARTMENTS
 DIM_ECON_SECTORS
 
 DIM_VACCINE_STRATA
-
-i_UNVACCINATED_STRATUM
-
-i_VACCINATED_STRATUM
-
-i_NEW_VAX_STRATUM
-
-VACCINE_GROUPS
 
 N_OUTPUT_COLS
 }
@@ -139,5 +109,4 @@ working age individuals.
 \item Indices and numbers of key groups.
 }
 }
-\keyword{datasets}
 \keyword{model_constant}

--- a/man/summary_constants.Rd
+++ b/man/summary_constants.Rd
@@ -9,7 +9,7 @@
 \format{
 An object of class \code{character} of length 3.
 
-An object of class \code{character} of length 3.
+An object of class \code{character} of length 2.
 }
 \usage{
 SUMMARY_MEASURES

--- a/tests/testthat/test-vaccination.R
+++ b/tests/testthat/test-vaccination.R
@@ -6,7 +6,7 @@ test_that("Vaccination: basic expectations", {
   })
   data <- get_data(output)
 
-  data_vaccinated <- data[data$vaccine_group == "vaccinated", ]
+  data_vaccinated <- data[data$compartment == "vaccinated", ]
   expect_gt(
     max(data_vaccinated$value), 0
   )
@@ -26,13 +26,11 @@ test_that("Vaccination: basic expectations", {
   expect_identical(
     sum(
       data[data$time == max(data$time) &
-        data$compartment %in% COMPARTMENTS[i_EPI_COMPARTMENTS] &
-        data$vaccine_group != "new_vaccinations", ]$value
+        data$compartment %in% COMPARTMENTS[i_EPI_COMPARTMENTS], ]$value
     ),
     sum(
       data[data$time == min(data$time) &
-        data$compartment %in% COMPARTMENTS[i_EPI_COMPARTMENTS] &
-        data$vaccine_group != "new_vaccinations", ]$value
+        data$compartment %in% COMPARTMENTS[i_EPI_COMPARTMENTS], ]$value
     ),
     tolerance = 1
   )


### PR DESCRIPTION
This PR makes changes to how vaccine groups are modelled in {daedalus}. The model trades explicit tracking of infection pathways of different vaccine groups for a gain in performance. There are some performance gains, but some country-pathogen-vaccine strategy combinations still result in a stiff system which slows down model runs.

1. Vaccine groups now share a single infection pathway, cutting the number of model compartments to 539 (49 age and economic groups $\times$ 11 epi and data compartments) from 1323. This improves performance in most cases by about 3x.

2. The state variable adds two compartments, one for vaccinated individuals who have a lower susceptibility to infection ($\tau \beta$; $\tau = 0.5$), and one for the number of new vaccinations per timestep.

3. Individuals in both susceptible and recovered compartments are considered eligible for vaccination. Vaccinated individuals transition at the rate $\psi$ into the susceptible compartment, but not into the recovered compartment. The vaccine-derived protection and waning dynamics need more work to ensure they have realistic transition rates, and/or to make transition rates independent and flexible.

4. The helper functions `values_to_state()`, `r_eff()`, `get_hospitalisations()`, `make_initial_state()`, `prepare_output()`, and `get_daily_vaccinations()` have been updated to reflect the reduced state size.

5. Tests have been updated to reflect reduced state size.

6. Reduced use of {rlang} for environment access and modification.

Tagging @patcatgit and @robj411 as well - I still can't find/confirm Kanchan - what is her GH id? Happy to tweak this implementation per feedback.