### PR TITLE
Add touchstone benchmarking

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -30,3 +30,4 @@
 ^doc$
 ^Meta$
 ^.*_cpp.sh$
+^touchstone$

--- a/.github/workflows/touchstone-comment.yaml
+++ b/.github/workflows/touchstone-comment.yaml
@@ -1,0 +1,26 @@
+name: Continuous Benchmarks (Comment)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_run:
+    workflows: ["Continuous Benchmarks (Receive)"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - uses: lorenzwalthert/touchstone/actions/comment@main
+        with: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/touchstone-receive.yaml
+++ b/.github/workflows/touchstone-receive.yaml
@@ -1,0 +1,59 @@
+# Modified to follow workflow in EpiNow2
+name: Continuous Benchmarks (Receive)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+on: 
+  pull_request:
+    paths:
+      # Where model code is defined: R/, src/, inst/include/
+      - "inst/include/**"
+      - "src/**"
+      - "R/**"
+      # Benchmarking code, config file, and manual trigger
+      - "touchstone/**"
+      - ".github/workflows/touchstone-*.yaml"
+      - ".benchmark"
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    # Allow benchmarking workflow to run for external contribs
+    outputs:
+      config: ${{ steps.read_touchstone_config.outputs.config }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - id: read_touchstone_config
+        run: |
+          content=`cat ./touchstone/config.json`
+          # the following lines are only required for multi line json
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          # end of optional handling for multi line json
+          echo "::set-output name=config::$content"
+  build:
+    needs: prepare
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - ${{ fromJson(needs.prepare.outputs.config) }}
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: lorenzwalthert/touchstone/actions/receive@main
+        with:
+          cache-version: 1
+          benchmarking_repo: ${{ matrix.config.benchmarking_repo }}
+          benchmarking_ref: ${{ matrix.config.benchmarking_ref }}
+          benchmarking_path: ${{ matrix.config.benchmarking_path }}

--- a/touchstone/.gitignore
+++ b/touchstone/.gitignore
@@ -1,0 +1,6 @@
+*
+!script.R
+!config.json
+!.gitignore
+!header.R
+!footer.R

--- a/touchstone/config.json
+++ b/touchstone/config.json
@@ -1,0 +1,5 @@
+{
+    "os": "ubuntu-20.04",
+    "r": "4.1.1",
+    "rspm": "https://packagemanager.rstudio.com/all/__linux__/focal/latest"
+}

--- a/touchstone/footer.R
+++ b/touchstone/footer.R
@@ -1,0 +1,10 @@
+# You can modify the PR comment footer here. You can use github markdown e.g.
+# emojis like :tada:.
+# This file will be parsed and evaluate within the context of
+# `benchmark_analyze` and should return the comment text as the last value.
+# See `?touchstone::pr_comment`
+link <- "https://lorenzwalthert.github.io/touchstone/articles/inference.html"
+glue::glue(
+  "\nFurther explanation regarding interpretation and",
+  " methodology can be found in the [documentation]({link})."
+)

--- a/touchstone/header.R
+++ b/touchstone/header.R
@@ -1,0 +1,13 @@
+# You can modify the PR comment header here. You can use github markdown e.g.
+# emojis like :tada:.
+# This file will be parsed and evaluate within the context of
+# `benchmark_analyze` and should return the comment text as the last value.
+# Available variables for glue substitution:
+# * ci: confidence interval
+# * branches: BASE and HEAD branches benchmarked against each other.
+# See `?touchstone::pr_comment`
+glue::glue(
+  "This is how benchmark results would change (along with a",
+  " {100 * ci}% confidence interval in relative change) if ",
+  "{system2('git', c('rev-parse', 'HEAD'), stdout = TRUE)} is merged into {branches[1]}:\n"
+)

--- a/touchstone/script.R
+++ b/touchstone/script.R
@@ -1,0 +1,27 @@
+# see `help(run_script, package = 'touchstone')` on how to run this
+# interactively
+
+# TODO OPTIONAL Add directories you want to be available in this file or during the
+# benchmarks.
+# touchstone::pin_assets("some/dir")
+
+# installs branches to benchmark
+touchstone::branch_install()
+
+# benchmark daedalus::daedalus()
+touchstone::benchmark_run(
+  test_daedalus = daedalus::daedalus("GBR", "influenza_2009", "elimination"),
+  n = 10
+)
+
+# benchmark daedalus::daedalus_rtm()
+touchstone::benchmark_run(
+  test_daedalus_rtm = daedalus::daedalus_rtm(
+    "GBR", "influenza_2009", "elimination",
+    10, 90
+  ),
+  n = 10
+)
+
+# create artifacts used downstream in the GitHub Action
+touchstone::benchmark_analyze()


### PR DESCRIPTION
This PR adds {touchstone} benchmarking.

1. Uses `main` over default `v1` tag generated by `touchstone::use_touchstone()`;
2. Uses simpler `config.json`;
3. Adds a few initial tests for `daedalus()` and `daedalus_rtm()`. Might be worth wrapping these up just to ensure this workflow doesn't break if or when these functions go away or the way we call them changes? Something to ponder.