### PR TITLE
Intial contact matrix support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 README.md linguist-generated=true
 man/*.Rd linguist-generated=true
+R/dust.R linguist-generated=true
+src/daedalus.cpp linguist-generated=true
+src/cpp11.cpp linguist-generated=true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus
 Title: Model Health, Social, and Economic Costs of a Pandemic
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus 0.2.2
+
+This version adds support for including contact matrices in the `daedalus` class object and using them in the FOI calculation.
+
 # daedalus 0.2.1
 
 This is a patch version of {daedalus} that builds up to combining `daedalus::daedalus()` with `daedalus::daedalus_rtm()`.

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -46,10 +46,20 @@ daedalus2_internal <- function(time_end, params) {
 #'
 #' @examples
 #' daedalus2(5, n_strata = 4)
-daedalus2 <- function(time_end = 100, ...) {
+daedalus2 <- function(time_end = 100, n_strata = 3, ...) {
   # NOTE: input checking
   # NOTE: parameter filtering
   params <- rlang::list2(...)
+
+  # all-ones matrix to make eigenvalue scaling easier
+  # demography scaling is in internal code
+  conmat <- matrix(1, n_strata, n_strata)
+  conmat <- conmat / n_strata
+
+  params <- c(
+    list(n_strata = n_strata, conmat = conmat), params
+  )
+
   output <- daedalus2_internal(time_end, params)
 
   # NOTE: needs to be compatible with `<daedalus_output>`

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -22,6 +22,8 @@ daedalus2_internal <- function(time_end, params) {
 #' (and in future \pkg{dust}). *This is a work in progress!*
 #'
 #' @inheritParams daedalus
+#' @param n_strata A single integer for the number of age or demographic groups.
+#' To be replaced with [daedalus()] like arguments in future.
 #' @param ... Optional named parameters for the model. See **Details** for more.
 #' @export
 #'
@@ -41,8 +43,6 @@ daedalus2_internal <- function(time_end, params) {
 #' - "sigma": The infectiousness rate.
 #'
 #' - "gamma": The recovery rate.
-#'
-#' - "n_strata": The number of strata (e.g. demography groups).
 #'
 #' @examples
 #' daedalus2(5, n_strata = 4)

--- a/R/dust.R
+++ b/R/dust.R
@@ -8,12 +8,9 @@ daedalus_ode <- structure(
   parameters = data.frame(
     name = c("I0", "N", "beta", "sigma", "gamma", "n_strata"),
     type = c("real_type", "real_type", "real_type", "real_type", "real_type", "int"),
-    constant = c(FALSE, TRUE, FALSE, FALSE, FALSE, FALSE)
-  ),
+    constant = c(FALSE, TRUE, FALSE, FALSE, FALSE, FALSE)),
   properties = list(
     time_type = "continuous",
     has_compare = FALSE,
-    has_adjoint = FALSE
-  ),
-  default_dt = NULL
-)
+    has_adjoint = FALSE),
+  default_dt = NULL)

--- a/R/dust.R
+++ b/R/dust.R
@@ -6,9 +6,9 @@ daedalus_ode <- structure(
   package = "daedalus",
   path = NULL,
   parameters = data.frame(
-    name = c("I0", "N", "beta", "sigma", "gamma", "n_strata"),
-    type = c("real_type", "real_type", "real_type", "real_type", "real_type", "int"),
-    constant = c(FALSE, TRUE, FALSE, FALSE, FALSE, FALSE)),
+    name = c("I0", "N", "beta", "sigma", "gamma", "n_strata", "conmat"),
+    type = c("real_type", "real_type", "real_type", "real_type", "real_type", "int", "real_type"),
+    constant = c(FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, TRUE)),
   properties = list(
     time_type = "continuous",
     has_compare = FALSE,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -7,6 +7,7 @@ Cov
 Covid
 Cpp
 EPPI
+FOI
 Forchini
 GH
 GNI

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -45,6 +45,7 @@ class daedalus_ode {
     real_type gamma;
     int n_strata;
     const std::vector<size_t> i_to_zero;
+    Eigen::MatrixXd conmat;
   };
 
   /// @brief Internal state - unclear purpose.
@@ -77,10 +78,17 @@ class daedalus_ode {
     const real_type gamma = dust2::r::read_real(pars, "gamma", 0.1);
     const int n_strata = dust2::r::read_int(pars, "n_strata", 3);
 
+    // handling compartments to zero
     const std::vector<size_t> i_to_zero =
         daedalus::helpers::zero_which(seq_DATA_COMPARTMENTS, n_strata);
 
-    return shared_state{N, I0, beta, sigma, gamma, n_strata, i_to_zero};
+    // handling contact matrix
+    const std::vector<size_t> vec_cm_dims(2, n_strata);  // for square matrix
+    const dust2::array::dimensions<2> cm_dims(vec_cm_dims.begin());
+    Eigen::MatrixXd conmat(n_strata, n_strata);
+    dust2::r::read_real_array(pars, cm_dims, conmat.data(), "conmat", true);
+
+    return shared_state{N, I0, beta, sigma, gamma, n_strata, i_to_zero, conmat};
   }
 
   /// @brief Updated shared parameters.
@@ -92,6 +100,7 @@ class daedalus_ode {
     shared.sigma = dust2::r::read_real(pars, "sigma", shared.sigma);
     shared.gamma = dust2::r::read_real(pars, "gamma", shared.gamma);
     shared.n_strata = dust2::r::read_int(pars, "n_strata", shared.n_strata);
+    // TODO: add conmat update method
   }
 
   /// @brief Set initial values of the IVP model.

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -141,8 +141,8 @@ class daedalus_ode {
     Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, N_COMPARTMENTS>> dx(
         &state_deriv[0], vec_size, N_COMPARTMENTS);
 
-    const auto rate_SE =
-        shared.beta * x.col(0).array() * x.col(2).array() / shared.N;
+    const auto rate_SE = shared.beta * x.col(0).array() *
+                         (shared.conmat * x.col(2)).array() / shared.N;
     const auto rate_EI = shared.sigma * x.col(1).array();
     const auto rate_IR = shared.gamma * x.col(2).array();
     dx.col(0) = -rate_SE;

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -30,6 +30,7 @@ const int N_COMPARTMENTS = N_EPI_COMPARTMENTS + N_DATA_COMPARTMENTS;
 // [[dust2::parameter(sigma, constant = FALSE)]]
 // [[dust2::parameter(gamma, constant = FALSE)]]
 // [[dust2::parameter(n_strata, constant = FALSE, type = "int")]]
+// [[dust2::parameter(conmat, constant = TRUE)]]
 class daedalus_ode {
  public:
   daedalus_ode() = delete;
@@ -100,7 +101,6 @@ class daedalus_ode {
     shared.sigma = dust2::r::read_real(pars, "sigma", shared.sigma);
     shared.gamma = dust2::r::read_real(pars, "gamma", shared.gamma);
     shared.n_strata = dust2::r::read_int(pars, "n_strata", shared.n_strata);
-    // TODO(pratik): add conmat update method?
   }
 
   /// @brief Set initial values of the IVP model.

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -100,7 +100,7 @@ class daedalus_ode {
     shared.sigma = dust2::r::read_real(pars, "sigma", shared.sigma);
     shared.gamma = dust2::r::read_real(pars, "gamma", shared.gamma);
     shared.n_strata = dust2::r::read_int(pars, "n_strata", shared.n_strata);
-    // TODO: add conmat update method
+    // TODO(pratik): add conmat update method?
   }
 
   /// @brief Set initial values of the IVP model.
@@ -110,7 +110,6 @@ class daedalus_ode {
   static void initial(real_type time, const shared_state &shared,
                       const internal_state &internal,
                       const rng_state_type &rng_state, real_type *state_next) {
-    // TODO(pratik): remove `internal` and `rng_state` as not used
     size_t vec_size = shared.n_strata;  // currently a single size_t
 
     // map an Eigen container

--- a/man/daedalus2.Rd
+++ b/man/daedalus2.Rd
@@ -4,12 +4,15 @@
 \alias{daedalus2}
 \title{DAEDALUS model implemented with dust}
 \usage{
-daedalus2(time_end = 100, ...)
+daedalus2(time_end = 100, n_strata = 3, ...)
 }
 \arguments{
 \item{time_end}{An integer-like value for the number of timesteps
 at which to return data. This is treated as the number of days with data
 returned for each day. Defaults to 300 days.}
+
+\item{n_strata}{A single integer for the number of age or demographic groups.
+To be replaced with \code{\link[=daedalus]{daedalus()}} like arguments in future.}
 
 \item{...}{Optional named parameters for the model. See \strong{Details} for more.}
 }
@@ -29,7 +32,6 @@ progress.
 \item "beta": The transmission rate of the infection.
 \item "sigma": The infectiousness rate.
 \item "gamma": The recovery rate.
-\item "n_strata": The number of strata (e.g. demography groups).
 }
 }
 }

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -144,7 +144,7 @@ class daedalus_ode {
         &state_deriv[0], vec_size, N_COMPARTMENTS);
 
     const auto rate_SE =
-        shared.beta * x.col(0).array() * x.col(2).array() / shared.N;
+        shared.beta * x.col(0).array() * (shared.conmat * x.col(2)).array() / shared.N;
     const auto rate_EI = shared.sigma * x.col(1).array();
     const auto rate_IR = shared.gamma * x.col(2).array();
     dx.col(0) = -rate_SE;

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -32,6 +32,7 @@ const int N_COMPARTMENTS = N_EPI_COMPARTMENTS + N_DATA_COMPARTMENTS;
 // [[dust2::parameter(sigma, constant = FALSE)]]
 // [[dust2::parameter(gamma, constant = FALSE)]]
 // [[dust2::parameter(n_strata, constant = FALSE, type = "int")]]
+// [[dust2::parameter(conmat, constant = TRUE)]]
 class daedalus_ode {
  public:
   daedalus_ode() = delete;
@@ -102,7 +103,6 @@ class daedalus_ode {
     shared.sigma = dust2::r::read_real(pars, "sigma", shared.sigma);
     shared.gamma = dust2::r::read_real(pars, "gamma", shared.gamma);
     shared.n_strata = dust2::r::read_int(pars, "n_strata", shared.n_strata);
-    // TODO(pratik): add conmat update method?
   }
 
   /// @brief Set initial values of the IVP model.
@@ -143,8 +143,8 @@ class daedalus_ode {
     Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, N_COMPARTMENTS>> dx(
         &state_deriv[0], vec_size, N_COMPARTMENTS);
 
-    const auto rate_SE =
-        shared.beta * x.col(0).array() * (shared.conmat * x.col(2)).array() / shared.N;
+    const auto rate_SE = shared.beta * x.col(0).array() *
+                         (shared.conmat * x.col(2)).array() / shared.N;
     const auto rate_EI = shared.sigma * x.col(1).array();
     const auto rate_IR = shared.gamma * x.col(2).array();
     dx.col(0) = -rate_SE;

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -47,6 +47,7 @@ class daedalus_ode {
     real_type gamma;
     int n_strata;
     const std::vector<size_t> i_to_zero;
+    Eigen::MatrixXd conmat;
   };
 
   /// @brief Internal state - unclear purpose.
@@ -79,10 +80,17 @@ class daedalus_ode {
     const real_type gamma = dust2::r::read_real(pars, "gamma", 0.1);
     const int n_strata = dust2::r::read_int(pars, "n_strata", 3);
 
+    // handling compartments to zero
     const std::vector<size_t> i_to_zero =
         daedalus::helpers::zero_which(seq_DATA_COMPARTMENTS, n_strata);
 
-    return shared_state{N, I0, beta, sigma, gamma, n_strata, i_to_zero};
+    // handling contact matrix
+    const std::vector<size_t> vec_cm_dims(2, n_strata);  // for square matrix
+    const dust2::array::dimensions<2> cm_dims(vec_cm_dims.begin());
+    Eigen::MatrixXd conmat(n_strata, n_strata);
+    dust2::r::read_real_array(pars, cm_dims, conmat.data(), "conmat", true);
+
+    return shared_state{N, I0, beta, sigma, gamma, n_strata, i_to_zero, conmat};
   }
 
   /// @brief Updated shared parameters.
@@ -94,6 +102,7 @@ class daedalus_ode {
     shared.sigma = dust2::r::read_real(pars, "sigma", shared.sigma);
     shared.gamma = dust2::r::read_real(pars, "gamma", shared.gamma);
     shared.n_strata = dust2::r::read_int(pars, "n_strata", shared.n_strata);
+    // TODO(pratik): add conmat update method?
   }
 
   /// @brief Set initial values of the IVP model.
@@ -103,7 +112,6 @@ class daedalus_ode {
   static void initial(real_type time, const shared_state &shared,
                       const internal_state &internal,
                       const rng_state_type &rng_state, real_type *state_next) {
-    // TODO(pratik): remove `internal` and `rng_state` as not used
     size_t vec_size = shared.n_strata;  // currently a single size_t
 
     // map an Eigen container


### PR DESCRIPTION
This PR is proof of concept of passing contact matrix data from R to C++ and mapping to an Eigen Matrix via `dust2::r::read_real_array()`.

All other contact data (consumer-worker matrix and within-sector contacts vec) can be passed in this way. If this seems reasonable, I'll draw the rest of the owl in a follow-up PR. Needs to be rebased on `main` following #62.