### PR TITLE
Add public concern social distancing to daedalus2()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ scratch*
 format-cpp.sh
 lint-cpp.sh
 format-R.sh
+.vscode

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus
 Title: Model Health, Social, and Economic Costs of a Pandemic
-Version: 0.2.8
+Version: 0.2.9
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# daedalus 0.2.9
+
+- Added public-concern social distancing to `daedalus2()`, and re-added it to `daedalus()`; this reverses the removal in v0.2.3. The functions are equivalent: social-distancing is active only when an NPI is active.
+
+- Added a filter on `NULL` to `daedalus2()` parameter collection step - this helps remove parameters and allows treating missing values as a meaningful indicator in the C++ code (as 0.0 can be a valid value in many cases).
+
+- **Removed** default response duration of 60 days in `daedalus2()` as this is not present in `daedalus()` leading to non-equivalence in tests.
+
 # daedalus 0.2.8
 
 ## Breaking changes

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -60,12 +60,13 @@ daedalus2_internal <- function(time_end, params, state, flags) {
 #'
 #' names(output)
 daedalus2 <- function(
-    country,
-    infection,
-    response_strategy = NULL,
-    vaccine_investment = NULL,
-    response_time = 30,
-    time_end = 100) {
+  country,
+  infection,
+  response_strategy = NULL,
+  vaccine_investment = NULL,
+  response_time = 30,
+  time_end = 100
+) {
   # prepare flags
   flags <- initial_flags()
 
@@ -83,7 +84,7 @@ daedalus2 <- function(
 
   # checks on interventions
   # also prepare the appropriate economic openness vectors
-  # allowing for a numeric vector, or NULL for no response
+  # allowing for a numeric vector, or NULL for truly response
   if (is.null(response_strategy)) {
     openness <- rep(1.0, N_ECON_SECTORS)
     response_time <- NULL # to be filtered out later

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -86,6 +86,7 @@ daedalus2 <- function(
   # allowing for a numeric vector, or NULL for no response
   if (is.null(response_strategy)) {
     openness <- rep(1.0, N_ECON_SECTORS)
+    response_time <- NULL # to be filtered out later
   } else if (is.numeric(response_strategy)) {
     checkmate::assert_numeric(
       response_strategy,
@@ -161,6 +162,9 @@ daedalus2 <- function(
       response_time = response_time
     )
   )
+
+  # filter out NULLs so missing values can be read as NAN in C++
+  parameters <- Filter(function(x) !is.null(x), parameters)
 
   output <- daedalus2_internal(time_end, parameters, initial_state, flags)
 

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -84,7 +84,7 @@ daedalus2 <- function(
 
   # checks on interventions
   # also prepare the appropriate economic openness vectors
-  # allowing for a numeric vector, or NULL for truly response
+  # allowing for a numeric vector, or NULL for truly no response
   if (is.null(response_strategy)) {
     openness <- rep(1.0, N_ECON_SECTORS)
     response_time <- NULL # to be filtered out later

--- a/R/ode.R
+++ b/R/ode.R
@@ -42,7 +42,7 @@ daedalus_rhs <- function(t, state, parameters) {
   state_ <- values_to_state(state)
 
   # remove delta vaccinations layer
-  state_ <- state_[, , -i_NEW_VAX_STRATUM]
+  state_ <- state_[,, -i_NEW_VAX_STRATUM]
 
   #### Parameter preparation ####
   beta <- parameters[["beta"]]
@@ -101,11 +101,12 @@ daedalus_rhs <- function(t, state, parameters) {
   d_state[, i_D, ] <- new_deaths
   new_deaths_total <- sum(new_deaths)
 
-  beta <- beta * if (switch) {
-    get_distancing_coefficient(new_deaths_total)
-  } else {
-    1.0
-  }
+  beta <- beta *
+    if (switch) {
+      get_distancing_coefficient(new_deaths_total)
+    } else {
+      1.0
+    }
 
   #### Force of infection calculations ####
   # NOTE: get total number in each age group infectious
@@ -203,8 +204,7 @@ daedalus_rhs <- function(t, state, parameters) {
   d_state <- values_to_state(c(d_state, d_vax_temp))
 
   # log new vaccinations
-  d_state[, c(i_S, i_R), i_NEW_VAX_STRATUM] <- state_[
-    ,
+  d_state[, c(i_S, i_R), i_NEW_VAX_STRATUM] <- state_[,
     c(i_S, i_R),
     i_UNVACCINATED_STRATUM
   ] *
@@ -213,8 +213,7 @@ daedalus_rhs <- function(t, state, parameters) {
   # NOTE: changes in S and R are on top of previous changes due to infection,
   # recovery, and waning
   # change in vaccinated: only susceptible and recovered are vaccinated
-  d_state[, c(i_S, i_R), i_VACCINATED_STRATUM] <- d_state[
-    ,
+  d_state[, c(i_S, i_R), i_VACCINATED_STRATUM] <- d_state[,
     c(i_S, i_R),
     i_VACCINATED_STRATUM
   ] +
@@ -222,8 +221,7 @@ daedalus_rhs <- function(t, state, parameters) {
     state_[, c(i_S, i_R), i_VACCINATED_STRATUM] * psi
 
   # change in unvaccinated: assume waning only for susceptible and recovered
-  d_state[, c(i_S, i_R), i_UNVACCINATED_STRATUM] <- d_state[
-    ,
+  d_state[, c(i_S, i_R), i_UNVACCINATED_STRATUM] <- d_state[,
     c(i_S, i_R),
     i_UNVACCINATED_STRATUM
   ] +

--- a/R/ode.R
+++ b/R/ode.R
@@ -42,7 +42,7 @@ daedalus_rhs <- function(t, state, parameters) {
   state_ <- values_to_state(state)
 
   # remove delta vaccinations layer
-  state_ <- state_[,, -i_NEW_VAX_STRATUM]
+  state_ <- state_[, , -i_NEW_VAX_STRATUM]
 
   #### Parameter preparation ####
   beta <- parameters[["beta"]]
@@ -99,6 +99,13 @@ daedalus_rhs <- function(t, state, parameters) {
   # as described in https://github.com/robj411/p2_drivers
   new_deaths <- state_[, i_H, ] * omega # row i by element i
   d_state[, i_D, ] <- new_deaths
+  new_deaths_total <- sum(new_deaths)
+
+  beta <- beta * if (switch) {
+    get_distancing_coefficient(new_deaths_total)
+  } else {
+    1.0
+  }
 
   #### Force of infection calculations ####
   # NOTE: get total number in each age group infectious
@@ -196,7 +203,8 @@ daedalus_rhs <- function(t, state, parameters) {
   d_state <- values_to_state(c(d_state, d_vax_temp))
 
   # log new vaccinations
-  d_state[, c(i_S, i_R), i_NEW_VAX_STRATUM] <- state_[,
+  d_state[, c(i_S, i_R), i_NEW_VAX_STRATUM] <- state_[
+    ,
     c(i_S, i_R),
     i_UNVACCINATED_STRATUM
   ] *
@@ -205,7 +213,8 @@ daedalus_rhs <- function(t, state, parameters) {
   # NOTE: changes in S and R are on top of previous changes due to infection,
   # recovery, and waning
   # change in vaccinated: only susceptible and recovered are vaccinated
-  d_state[, c(i_S, i_R), i_VACCINATED_STRATUM] <- d_state[,
+  d_state[, c(i_S, i_R), i_VACCINATED_STRATUM] <- d_state[
+    ,
     c(i_S, i_R),
     i_VACCINATED_STRATUM
   ] +
@@ -213,7 +222,8 @@ daedalus_rhs <- function(t, state, parameters) {
     state_[, c(i_S, i_R), i_VACCINATED_STRATUM] * psi
 
   # change in unvaccinated: assume waning only for susceptible and recovered
-  d_state[, c(i_S, i_R), i_UNVACCINATED_STRATUM] <- d_state[,
+  d_state[, c(i_S, i_R), i_UNVACCINATED_STRATUM] <- d_state[
+    ,
     c(i_S, i_R),
     i_UNVACCINATED_STRATUM
   ] +

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -270,10 +270,10 @@ class daedalus_ode {
     std::vector<size_t> idx_hosp =
         daedalus::helpers::get_state_idx({iH + 1}, n_strata, N_VAX_STRATA);
 
-    // NOTE: assume response ends after 60 days - awaiting better default
-    daedalus::events::response npi(std::string("npi"), response_time,
-                                   response_time + 60.0, hospital_capacity,
-                                   gamma_Ia, i_npi_flag, idx_hosp, i_ipr);
+    // NOTE: no response end time specified for now; represented by 0.0
+    daedalus::events::response npi(std::string("npi"), response_time, 0.0,
+                                   hospital_capacity, gamma_Ia, i_npi_flag,
+                                   idx_hosp, i_ipr);
     daedalus::events::response vaccination(std::string("vaccination"),
                                            vax_start_time, 0.0, 0.0, 0.0,
                                            i_vax_flag, {0}, 0);

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -102,7 +102,6 @@ class daedalus_ode {
     TensorMat t_comm_inf, t_foi, workplace_infected, t_comm_inf_age,
         consumer_worker_infections, susc_workers, sToE, eToIs, eToIa, isToR,
         iaToR, isToH, hToR, hToD, rToS;
-    double nu_eff, beta_tmp;
   };
 
   static internal_state build_internal(const shared_state &shared) {
@@ -124,20 +123,13 @@ class daedalus_ode {
     TensorMat t_comm_inf_age(shared.n_age_groups, N_VAX_STRATA);
     t_comm_inf_age.setZero();
 
-    // effective vaccination rate is initially the vaccination rate
-    double nu_eff = shared.nu;
-
-    // initial temporary beta is original beta
-    double beta_tmp = shared.beta;
-
     // clang-format off
     return internal_state{
       t_comm_inf, t_foi, workplace_infected,
       t_comm_inf_age,
       consumer_worker_infections,
       susc_workers,
-      sToE, eToIs, eToIa, isToR, iaToR, isToH, hToR, hToD, rToS,
-      nu_eff, beta_tmp
+      sToE, eToIs, eToIa, isToR, iaToR, isToH, hToR, hToD, rToS
     };
     // clang-format on
   }
@@ -346,7 +338,7 @@ class daedalus_ode {
     // TODO(pratik): change in future so public-concern is independent of NPIs
     internal.hToD = shared.omega * t_x.chip(iH, i_COMPS);  // new deaths
     Eigen::Tensor<double, 0> total_deaths = internal.hToD.sum();
-    internal.beta_tmp =
+    const double beta_tmp =
         shared.beta *
         daedalus::events::switch_by_flag(
             daedalus::helpers::get_concern_coefficient(total_deaths(0)),
@@ -368,7 +360,7 @@ class daedalus_ode {
 
     // calculate C * I_w and C * I_cons for a n_econ_groups-length array
     internal.workplace_infected =
-        internal.beta_tmp *
+        beta_tmp *
         shared.cm_work *  // this is a 2D tensor with dims (n_econ_grps, 1)
         daedalus::events::switch_by_flag(shared.openness,
                                          state[shared.i_npi_flag]) *  // scale β
@@ -381,7 +373,7 @@ class daedalus_ode {
         Eigen::array<Eigen::Index, 2>{n_age_groups, 1});
 
     internal.consumer_worker_infections =
-        internal.beta_tmp *
+        beta_tmp *
         daedalus::events::switch_by_flag(shared.openness,
                                          state[shared.i_npi_flag]) *  // scale β
         shared.cm_cons_work.contract(internal.t_comm_inf_age, product_dims);
@@ -392,7 +384,7 @@ class daedalus_ode {
                    Eigen::array<Eigen::Index, 2>{n_econ_groups, N_VAX_STRATA});
 
     internal.sToE = t_x.chip(iS, i_COMPS) * internal.t_foi *
-                    internal.beta_tmp;  // dims (n_strata, 2)
+                    beta_tmp;  // dims (n_strata, 2)
 
     // add workplace infections within sectors as
     // (S_w * (C_w * I_w and C_cons_wo * I_cons))
@@ -435,7 +427,7 @@ class daedalus_ode {
 
     // vaccination related changes
     // calculate vaccination rate
-    internal.nu_eff =
+    const double nu_eff =
         daedalus::helpers::scale_nu(t_x, shared.nu, shared.uptake_limit,
                                     shared.popsize, n_strata) *
         state[shared.i_vax_flag];
@@ -444,18 +436,18 @@ class daedalus_ode {
     // .stride() operator limited by start point
     // S => S_v
     t_dx.chip(iS, i_COMPS).chip(0, 1) +=
-        -internal.nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) +
+        -nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) +
         shared.psi * t_x.chip(iS, i_COMPS).chip(1, 1);
     t_dx.chip(iS, i_COMPS).chip(1, 1) +=
-        internal.nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) -
+        nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) -
         shared.psi * t_x.chip(iS, i_COMPS).chip(1, 1);
 
     // R => R_v
     t_dx.chip(iR, i_COMPS).chip(0, 1) +=
-        -internal.nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1) +
+        -nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1) +
         shared.psi * t_x.chip(iR, i_COMPS).chip(1, 1);
     t_dx.chip(iR, i_COMPS).chip(1, 1) +=
-        internal.nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1) -
+        nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1) -
         shared.psi * t_x.chip(iR, i_COMPS).chip(1, 1);
 
     // get IPR (incidence prevalence ratio) as growth flag

--- a/inst/include/daedalus_events.h
+++ b/inst/include/daedalus_events.h
@@ -19,7 +19,7 @@ namespace events {
 
 /// @brief Get values depending on a flag variable
 /// @tparam T
-/// @param value A value, typically of the opennness coefficient. For an 80%
+/// @param value A value, typically of the openness coefficient. For an 80%
 /// closure of a sector, the openness coefficient would be 0.2.
 /// @param flag Either 0.0 or 1.0.
 /// @return Either `value` when `flag` = 1.0, or 1.0 when `flag` = 0.0.
@@ -157,7 +157,7 @@ class response {
   }
 };
 
-/// @brief Flattern multiple vectors of dust2 events into a single events vec.
+/// @brief Flatten multiple vectors of dust2 events into a single events vec.
 /// @param events_vecs A vector of event vectors.
 /// @return A combined vector of events.
 inline dust2::ode::events_type<double> get_combined_events(

--- a/inst/include/daedalus_helpers.h
+++ b/inst/include/daedalus_helpers.h
@@ -92,6 +92,20 @@ inline double scale_nu(
 
   return scaled_nu;
 }
+
+/// @brief Get a coefficient of public concern over epidemic deaths. Used to
+/// implement spontaneous social distancing, potentially in the absence of NPIs,
+/// with lower concern coefficients indicating higher concern and reduced
+/// social contacts.
+/// @param new_deaths The total number of new deaths at time t.
+/// @param rate The rate at which concern rises with each new death.
+/// @param lower_limit The limit to
+/// @return A value in the range 0.0 - 1.0, higher values indicate less concern.
+inline double get_concern_coefficient(const double &new_deaths,
+                                      const double &rate = 0.001,
+                                      const double &lower_limit = 0.2) {
+  return std::pow(1.0 - rate, new_deaths) * (1.0 - lower_limit) + lower_limit;
+}
 }  // namespace helpers
 
 }  // namespace daedalus

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -248,8 +248,9 @@ class daedalus_ode {
         dust2::r::read_real(pars, "response_time", NAN);
     // hospital capacity data
     const real_type hospital_capacity =
-        std::isnan(response_time) ? NAN :
-        dust2::r::read_real(pars, "hospital_capacity", NAN);
+        std::isnan(response_time)
+            ? NAN
+            : dust2::r::read_real(pars, "hospital_capacity", NAN);
     // handling openness vector
     TensorMat openness(n_econ_groups, 1);
     dust2::r::read_real_vector(pars, n_econ_groups, openness.data(), "openness",
@@ -271,10 +272,10 @@ class daedalus_ode {
     std::vector<size_t> idx_hosp =
         daedalus::helpers::get_state_idx({iH + 1}, n_strata, N_VAX_STRATA);
 
-    // NOTE: assume response ends after 60 days - awaiting better default
-    daedalus::events::response npi(std::string("npi"), response_time,
-                                   response_time + 60.0, hospital_capacity,
-                                   gamma_Ia, i_npi_flag, idx_hosp, i_ipr);
+    // NOTE: no response end time specified for now; represented by 0.0
+    daedalus::events::response npi(std::string("npi"), response_time, 0.0,
+                                   hospital_capacity, gamma_Ia, i_npi_flag,
+                                   idx_hosp, i_ipr);
     daedalus::events::response vaccination(std::string("vaccination"),
                                            vax_start_time, 0.0, 0.0, 0.0,
                                            i_vax_flag, {0}, 0);
@@ -352,7 +353,7 @@ class daedalus_ode {
         daedalus::events::switch_by_flag(
             daedalus::helpers::get_concern_coefficient(total_deaths(0)),
             state[shared.i_npi_flag]);
-    
+
     // all chip ops on dim N have dim N-1
     // compartmental transitions
     // Susceptible (unvaccinated) to exposed

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -104,7 +104,7 @@ class daedalus_ode {
     TensorMat t_comm_inf, t_foi, workplace_infected, t_comm_inf_age,
         consumer_worker_infections, susc_workers, sToE, eToIs, eToIa, isToR,
         iaToR, isToH, hToR, hToD, rToS;
-    double nu_eff;
+    double nu_eff, beta_tmp;
   };
 
   static internal_state build_internal(const shared_state &shared) {
@@ -129,6 +129,9 @@ class daedalus_ode {
     // effective vaccination rate is initially the vaccination rate
     double nu_eff = shared.nu;
 
+    // initial temporary beta is original beta
+    double beta_tmp = shared.beta;
+
     // clang-format off
     return internal_state{
       t_comm_inf, t_foi, workplace_infected,
@@ -136,7 +139,7 @@ class daedalus_ode {
       consumer_worker_infections,
       susc_workers,
       sToE, eToIs, eToIa, isToR, iaToR, isToH, hToR, hToD, rToS,
-      nu_eff
+      nu_eff, beta_tmp
     };
     // clang-format on
   }
@@ -242,9 +245,10 @@ class daedalus_ode {
     // response time is only 0.0 when response is NULL or 'none'
     // this is used to set hosp capacity to NAN so the response is not triggered
     const real_type response_time =
-        dust2::r::read_real(pars, "response_time", 0.0);
+        dust2::r::read_real(pars, "response_time", NAN);
     // hospital capacity data
     const real_type hospital_capacity =
+        std::isnan(response_time) ? NAN :
         dust2::r::read_real(pars, "hospital_capacity", NAN);
     // handling openness vector
     TensorMat openness(n_econ_groups, 1);
@@ -338,6 +342,17 @@ class daedalus_ode {
                                      daedalus::constants::N_COMPARTMENTS,
                                      N_VAX_STRATA);
 
+    // calculate total deaths and scale beta by concern, but only if an
+    // NPI is active
+    // TODO(pratik): change in future so public-concern is independent of NPIs
+    internal.hToD = shared.omega * t_x.chip(iH, i_COMPS);  // new deaths
+    Eigen::Tensor<double, 0> total_deaths = internal.hToD.sum();
+    internal.beta_tmp =
+        shared.beta *
+        daedalus::events::switch_by_flag(
+            daedalus::helpers::get_concern_coefficient(total_deaths(0)),
+            state[shared.i_npi_flag]);
+    
     // all chip ops on dim N have dim N-1
     // compartmental transitions
     // Susceptible (unvaccinated) to exposed
@@ -354,7 +369,7 @@ class daedalus_ode {
 
     // calculate C * I_w and C * I_cons for a n_econ_groups-length array
     internal.workplace_infected =
-        shared.beta *
+        internal.beta_tmp *
         shared.cm_work *  // this is a 2D tensor with dims (n_econ_grps, 1)
         daedalus::events::switch_by_flag(shared.openness,
                                          state[shared.i_npi_flag]) *  // scale β
@@ -367,7 +382,7 @@ class daedalus_ode {
         Eigen::array<Eigen::Index, 2>{n_age_groups, 1});
 
     internal.consumer_worker_infections =
-        shared.beta *
+        internal.beta_tmp *
         daedalus::events::switch_by_flag(shared.openness,
                                          state[shared.i_npi_flag]) *  // scale β
         shared.cm_cons_work.contract(internal.t_comm_inf_age, product_dims);
@@ -378,7 +393,7 @@ class daedalus_ode {
                    Eigen::array<Eigen::Index, 2>{n_econ_groups, N_VAX_STRATA});
 
     internal.sToE = t_x.chip(iS, i_COMPS) * internal.t_foi *
-                    shared.beta;  // dims (n_strata, 2)
+                    internal.beta_tmp;  // dims (n_strata, 2)
 
     // add workplace infections within sectors as
     // (S_w * (C_w * I_w and C_cons_wo * I_cons))
@@ -403,7 +418,6 @@ class daedalus_ode {
 
     internal.isToH = shared.eta * t_x.chip(iIs, i_COMPS);
     internal.hToR = shared.gamma_H * t_x.chip(iH, i_COMPS);
-    internal.hToD = shared.omega * t_x.chip(iH, i_COMPS);
 
     internal.rToS = shared.rho * t_x.chip(iR, i_COMPS);
 

--- a/tests/testthat/test-daedalus2_events.R
+++ b/tests/testthat/test-daedalus2_events.R
@@ -46,13 +46,7 @@ test_that("daedalus2: root-finding events launch at each appropriate root", {
       output$event_data$name
     )
   )
-
-  # expect event ends at defined time
-  default_duration <- 60.0
-  expect_identical(
-    diff(output$event_data$time),
-    default_duration
-  )
+  # NOTE: response duration feature removed
 
   # expect vaccination is launched if chosen and does not end
   vax_time <- 33

--- a/tests/testthat/test-equivalence.R
+++ b/tests/testthat/test-equivalence.R
@@ -2,6 +2,7 @@ test_that("daedalus() and daedalus2() are equivalent", {
   # Excluding economic infections
   x <- daedalus_infection("sars_cov_1", rho = 0.0)
   ct <- daedalus_country("GBR")
+  ct$hospital_capacity <- 1e7
   # set workers to 1 to discount effect
   ct$workers <- rep(1, length(ct$workers))
   # modify vaccination to fit needs
@@ -13,11 +14,19 @@ test_that("daedalus() and daedalus2() are equivalent", {
   )
 
   # get outputs
-  output_daedalus2 <- daedalus2(ct, x, time_end = 399) # one less timestep
+  # NOTE: response specified as 'none' rather than NULL because `daedalus()`
+  # triggers public-concern distancing even when response is 'none'
+  output_daedalus2 <- daedalus2(
+    ct,
+    x,
+    response_strategy = "elimination",
+    response_time = 2,
+    time_end = 399
+  ) # one less timestep
   output_daedalus <- daedalus(
     ct,
     x,
-    "none",
+    "elimination",
     vax,
     response_time = 2,
     time_end = 400,
@@ -29,5 +38,5 @@ test_that("daedalus() and daedalus2() are equivalent", {
   fs_daedalus2 <- sum(output_daedalus2$data$new_inf)
 
   # a small difference is okay
-  expect_identical(fs_daedalus2, fs_daedalus$value, tolerance = 1e-6)
+  expect_identical(fs_daedalus2, fs_daedalus$value, tolerance = 1e-5)
 })


### PR DESCRIPTION
This PR adds the public-concern social distancing mechanism to `daedalus2()`. Also re-added it to `daedalus()`; this reverses the removal in v0.2.3. The functions are equivalent: social-distancing is active only when an NPI is active.

Other changes:
- Added a filter on `NULL` to `daedalus2()` parameter collection step - this helps remove parameters and allows treating missing values as a meaningful indicator in the C++ code (as 0.0 can be a valid value in many cases).
- **Removed** default response duration of 60 days in `daedalus2()` as this is not present in `daedalus()` leading to non-equivalence in tests.