### PR TITLE
Record new vaccinations in daedalus2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -35,3 +35,4 @@
 ^touchstone$
 ^format-R.sh$
 ^air.toml$
+^\.vscode$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus
 Title: Model Health, Social, and Economic Costs of a Pandemic
-Version: 0.2.10
+Version: 0.2.11
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# daedalus 0.2.11
+
+This patch version adds logging of new vaccinations in each age and economic group.
+
+- `daedalus2()` now returns data on new vaccinations and is compatible with `get_new_vaccinations()`; new vaccinations are stored as a vector of the size of age + economic groups after the main state but before the model flags;
+
+- `daedalus_ode` does not zero new vaccinations - this is handled by `get_new_vaccinations()`;
+
+- `daedalus2()` accepts optional ODE control arguments for _dust2_ via `...`;
+
+- Internal function `prepare_output_cpp()` accommodates new vaccination data in `output`.
+
 # daedalus 0.2.10
 
 - `daedalus_ode` class no longer zeroes data compartments for new infections and new hospitalisations --- this is handled by the pre-existing `get_incidence()` function. This change will be reversed in a future rewrite of `get_incidence()`;

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -61,8 +61,7 @@ daedalus2_internal <- function(time_end, params, state, flags) {
   sys_params <- list(daedalus_ode, pars = params)
   sys <- do.call(dust2::dust_system_create, sys_params)
 
-  # convert state to vector and add initial flags
-  state <- as.vector(state)
+  # add initial flags
   state <- c(state, flags)
   dust2::dust_system_set_state(sys, state)
 
@@ -105,8 +104,7 @@ daedalus2 <- function(
   response_strategy = NULL,
   vaccine_investment = NULL,
   response_time = 30,
-  time_end = 100
-) {
+    time_end = 100) {
   # prepare flags
   flags <- initial_flags()
 
@@ -187,7 +185,17 @@ daedalus2 <- function(
   }
 
   #### Prepare initial state and parameters ####
-  initial_state <- make_initial_state2(country)
+  initial_state <- as.vector(make_initial_state2(country))
+
+  # add state for new vaccinations by age group and econ sector
+  state_new_vax <- numeric(
+    length(get_data(country, "demography")) +
+      length(get_data(country, "workers"))
+  )
+  initial_state <- c(
+    initial_state,
+    state_new_vax
+  )
 
   # prepare susceptibility matrix for vaccination
   susc <- make_susc_matrix(vaccine_investment, country)

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -239,21 +239,19 @@ daedalus2 <- function(
     ode_control
   )
 
-  # # NOTE: needs to be compatible with `<daedalus_output>`
-  # # or equivalent from `{daedalus.compare}`
-  # output <- list(
-  #   total_time = time_end,
-  #   model_data = prepare_output_cpp(output$data, country),
-  #   country_parameters = unclass(country),
-  #   infection_parameters = unclass(infection),
-  #   response_data = list(
-  #     response_strategy = response_strategy,
-  #     openness = openness,
-  #     closure_info = get_daedalus2_response_times(output, time_end)
-  #   )
-  # )
+  # NOTE: needs to be compatible with `<daedalus_output>`
+  # or equivalent from `{daedalus.compare}`
+  output <- list(
+    total_time = time_end,
+    model_data = prepare_output_cpp(output$data, country),
+    country_parameters = unclass(country),
+    infection_parameters = unclass(infection),
+    response_data = list(
+      response_strategy = response_strategy,
+      openness = openness,
+      closure_info = get_daedalus2_response_times(output, time_end)
+    )
+  )
 
-  # as_daedalus_output(output)
-
-  output
+  as_daedalus_output(output)
 }

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -150,8 +150,16 @@ daedalus2 <- function(
       len = N_ECON_SECTORS
     )
     openness <- response_strategy
-  } else if (response_strategy %in% names(daedalus::closure_data)) {
+  } else if (
+    length(response_strategy) == 1 &&
+      response_strategy %in% names(daedalus::closure_data)
+  ) {
     openness <- daedalus::closure_data[[response_strategy]]
+  } else {
+    cli::cli_abort(
+      "Got an unexpected value for `response_strategy`. Options are `NULL`, \
+      a numeric vector, or a recognised strategy. See function docs."
+    )
   }
 
   # checks on vaccination

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ data <- daedalus("Canada", "influenza_1918")
 
 # get pandemic costs as a total in million dollars
 get_costs(data, "total")
-#> [1] 1621184
+#> [1] 1627703
 
 # disaggregate total for economic, education, and health costs
 get_costs(data, "domain")
 #>     economic    education   life_value   life_years 
-#>    33680.950     2201.333  1585301.497 34425656.823
+#>    33787.966     2207.265  1591707.843 34564774.017
 ```
 
 Users can select infection parameters from among seven epidemics caused

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -254,7 +254,9 @@ class daedalus_ode {
                                true);
 
     // RELATIVE LOCATIONS OF RESPONSE-RELATED FLAGS
-    const int total_compartments = n_strata * N_VAX_STRATA * N_COMPARTMENTS;
+    // add n_strata to the end for new vaccinations data
+    const int total_compartments =
+        (n_strata * N_VAX_STRATA * N_COMPARTMENTS) + n_strata;
     const size_t i_ipr = total_compartments + daedalus::constants::i_rel_IPR;
     const size_t i_npi_flag =
         total_compartments + daedalus::constants::i_rel_NPI_FLAG;

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -459,8 +459,8 @@ class daedalus_ode {
         nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1) -
         shared.psi * t_x.chip(iR, i_COMPS).chip(1, 1);
 
-    t_new_vax = internal.nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) +
-                internal.nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1);
+    t_new_vax = nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) +
+                nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1);
 
     // get IPR (incidence prevalence ratio) as growth flag
     const Eigen::Tensor<double, 0> incidence = internal.sToE.sum();

--- a/man/daedalus2.Rd
+++ b/man/daedalus2.Rd
@@ -10,7 +10,8 @@ daedalus2(
   response_strategy = NULL,
   vaccine_investment = NULL,
   response_time = 30,
-  time_end = 100
+  time_end = 100,
+  ...
 )
 }
 \arguments{
@@ -58,6 +59,8 @@ Defaults to 30 days.}
 \item{time_end}{An integer-like value for the number of timesteps
 at which to return data. This is treated as the number of days with data
 returned for each day. Defaults to 300 days.}
+
+\item{...}{Optional arguments that are passed to \code{\link[dust2:dust_ode_control]{dust2::dust_ode_control()}}.}
 }
 \description{
 \code{daedalus::daedalus2()} will eventually replace \code{daedalus::daedalus()} with

--- a/man/daedalus2_internal.Rd
+++ b/man/daedalus2_internal.Rd
@@ -4,7 +4,7 @@
 \alias{daedalus2_internal}
 \title{Internal function for daedalus2}
 \usage{
-daedalus2_internal(time_end, params, state, flags)
+daedalus2_internal(time_end, params, state, flags, ode_control)
 }
 \value{
 A list of state values as returned by \code{dust2::dust_unpack_state()}.

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -461,8 +461,8 @@ class daedalus_ode {
         nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1) -
         shared.psi * t_x.chip(iR, i_COMPS).chip(1, 1);
 
-    t_new_vax = internal.nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) +
-                internal.nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1);
+    t_new_vax = nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) +
+                nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1);
 
     // get IPR (incidence prevalence ratio) as growth flag
     const Eigen::Tensor<double, 0> incidence = internal.sToE.sum();

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -256,7 +256,9 @@ class daedalus_ode {
                                true);
 
     // RELATIVE LOCATIONS OF RESPONSE-RELATED FLAGS
-    const int total_compartments = n_strata * N_VAX_STRATA * N_COMPARTMENTS;
+    // add n_strata to the end for new vaccinations data
+    const int total_compartments =
+        (n_strata * N_VAX_STRATA * N_COMPARTMENTS) + n_strata;
     const size_t i_ipr = total_compartments + daedalus::constants::i_rel_IPR;
     const size_t i_npi_flag =
         total_compartments + daedalus::constants::i_rel_NPI_FLAG;

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -114,7 +114,6 @@ class daedalus_ode {
               rToS = mat2d, t_comm_inf = mat2d, t_foi = mat2d;
 
     // infection related
-
     TensorMat mat2d_econ(shared.n_econ_groups, N_VAX_STRATA);
     mat2d_econ.setZero();
     TensorMat workplace_infected = mat2d_econ,
@@ -166,6 +165,7 @@ class daedalus_ode {
                           {"dead_vax", dim_vec},
                           {"new_infections_vax", dim_vec},
                           {"new_hosp_vax", dim_vec},
+                          {"new_vax", dim_vec},
                           {"ipr", dim_flag},
                           {"npi_flag", dim_flag},
                           {"vax_flag", dim_flag}};
@@ -337,6 +337,10 @@ class daedalus_ode {
     Eigen::TensorMap<TensorAry> t_dx(state_deriv, n_strata,
                                      daedalus::constants::N_COMPARTMENTS,
                                      N_VAX_STRATA);
+    Eigen::TensorMap<Eigen::Tensor<double, 1>> t_new_vax(
+        state_deriv +
+            (n_strata * daedalus::constants::N_COMPARTMENTS * N_VAX_STRATA),
+        n_strata);
 
     // calculate total deaths and scale beta by concern, but only if an
     // NPI is active
@@ -439,7 +443,7 @@ class daedalus_ode {
 
     // TODO(pratik): flexible way of selecting multiple cols from i-th layer
     // .stride() operator limited by start point
-    // S => S_v
+    // S => S_v and S_v => S
     t_dx.chip(iS, i_COMPS).chip(0, 1) +=
         -nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) +
         shared.psi * t_x.chip(iS, i_COMPS).chip(1, 1);
@@ -447,13 +451,16 @@ class daedalus_ode {
         nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) -
         shared.psi * t_x.chip(iS, i_COMPS).chip(1, 1);
 
-    // R => R_v
+    // R => R_v and R_v => R
     t_dx.chip(iR, i_COMPS).chip(0, 1) +=
         -nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1) +
         shared.psi * t_x.chip(iR, i_COMPS).chip(1, 1);
     t_dx.chip(iR, i_COMPS).chip(1, 1) +=
         nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1) -
         shared.psi * t_x.chip(iR, i_COMPS).chip(1, 1);
+
+    t_new_vax = internal.nu_eff * t_x.chip(iS, i_COMPS).chip(0, 1) +
+                internal.nu_eff * t_x.chip(iR, i_COMPS).chip(0, 1);
 
     // get IPR (incidence prevalence ratio) as growth flag
     const Eigen::Tensor<double, 0> incidence = internal.sToE.sum();

--- a/tests/testthat/test-daedalus2.R
+++ b/tests/testthat/test-daedalus2.R
@@ -110,6 +110,16 @@ test_that("daedalus2: Can run with ISO3 country parameter", {
   expect_length(data, N_OUTPUT_COLS)
 })
 
+test_that("daedalus2: Can run with ODE control arguments", {
+  expect_no_condition(
+    daedalus2("GBR", "influenza_1918", atol = 1e-5)
+  )
+  expect_error(
+    daedalus2("GBR", "influenza_1918", dummy = 1e-5),
+    "unused argument"
+  )
+})
+
 # test that daedalus runs for all epidemic infection parameter sets
 test_that("daedalus2: Runs for all country x infection x response", {
   country_infection_combos <- data.table::CJ(
@@ -308,6 +318,7 @@ test_that("daedalus2: responses triggered by hospital capacity event", {
   )
 })
 
+# NOTE: see PR #83 for a reprex
 skip("Root jumping causes test to fail")
 test_that("daedalus2: responses ended by epidemic growth", {
   # start response early
@@ -341,5 +352,24 @@ test_that("daedalus2: responses ended by epidemic growth", {
   expect_identical(
     event_data[event_data$name == "npi_state_off", "time"],
     end_time
+  )
+})
+
+test_that("daedalus2: Errors and messages", {
+  expect_error(
+    daedalus2(
+      "GBR",
+      "sars_cov_1",
+      as.character(1:49)
+    ),
+    "Got an unexepected value for `response_strategy`."
+  )
+  expect_error(
+    daedalus2(
+      "GBR",
+      "sars_cov_1",
+      1:50
+    ),
+    "Assertion on 'response_strategy' failed: Must have length"
   )
 })

--- a/tests/testthat/test-daedalus2.R
+++ b/tests/testthat/test-daedalus2.R
@@ -20,6 +20,9 @@ test_that("daedalus2: basic expectations", {
     (N_AGE_GROUPS + N_ECON_SECTORS) *
     N_VACCINE_STRATA
 
+  expected_rows <- expected_rows +
+    ((N_AGE_GROUPS + N_ECON_SECTORS) * (time_end + 1L))
+
   expect_identical(nrow(data), expected_rows)
   expect_named(
     data,

--- a/tests/testthat/test-daedalus2_events.R
+++ b/tests/testthat/test-daedalus2_events.R
@@ -32,6 +32,7 @@ test_that("daedalus2: root-finding events launch at each appropriate root", {
   )
 })
 
+# NOTE: this test will/should be reinstated when daedalus2() replaces daedalus()
 skip("Full event data is no longer returned for compliance with output class")
 test_that("Vaccination events launch as expected", {
   # expect vaccination is launched if chosen and does not end

--- a/tests/testthat/test-output_helpers.R
+++ b/tests/testthat/test-output_helpers.R
@@ -16,6 +16,10 @@ test_that("Daily incidence: basic expectations", {
 
   expect_error(get_incidence(data, measures = "dummy"))
   expect_error(get_incidence(data, groups = "dummy"))
+  expect_error(
+    get_incidence("dummy_data"),
+    "(Expected `data`)*(data.frame)*(daedalus_output)"
+  )
 })
 
 test_that("Epidemic summary: basic expectations", {
@@ -41,6 +45,10 @@ test_that("Epidemic summary: basic expectations", {
 
   expect_error(get_epidemic_summary(data, measures = "dummy"))
   expect_error(get_epidemic_summary(data, groups = "dummy"))
+  expect_error(
+    get_epidemic_summary("dummy_data"),
+    "(Expected `data` to be)*(data.frame)*(daedalus_output)"
+  )
 })
 
 # Test get_new_vaccinations() - expect that there are no
@@ -61,6 +69,10 @@ test_that("New vaccinations: basic expectations", {
     data,
     groups = c("age_group", "econ_sector")
   ))
+  expect_error(
+    get_new_vaccinations("dummy_data"),
+    "(Expected `data` to be)*(data.frame)*(daedalus_output)"
+  )
   expect_error(get_new_vaccinations(
     data,
     groups = c("age_group", "vaccine_group")

--- a/vignettes/daedalus-two.Rmd
+++ b/vignettes/daedalus-two.Rmd
@@ -62,6 +62,19 @@ ggplot(data, aes(time, value)) +
     x = "Time", y = "Vaccinated susceptibles (prevalence)",
     caption = "Vaccinated susceptibles decrease due to infections."
   )
+
+# plot new vaccinations (incidence)
+# NOTE: dashboard shows cumulative vaccinations which are recalculated
+vax_data <- get_new_vaccinations(output, groups = "age_group")
+
+ggplot(vax_data, aes(time, new_vaccinations)) +
+  geom_line(
+    aes(col = age_group)
+  ) +
+  labs(
+    x = "Time",
+    y = "New vaccinations (incidence)"
+  )
 ```
 
 Check that fully protective (non-leaky) vaccination does not see a mid-epidemic reduction in vaccinated susceptibles.


### PR DESCRIPTION
This patch version adds logging of new vaccinations in each age and economic group.

- `daedalus2()` now returns data on new vaccinations and is compatible with `get_new_vaccinations()`; new vaccinations are stored as a vector of the size of age + economic groups after the main state but before the model flags;
- `daedalus_ode` does not zero new vaccinations - this is handled by `get_new_vaccinations()` --- something to change once `daedalus2()` becomes `daedalus()`;
- `daedalus2()` accepts optional ODE control arguments for _dust2_ via `...`;
- Internal function `prepare_output_cpp()` accommodates new vaccination data in `output`.