### PR TITLE
Add response duration option for NPIs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus
 Title: Model Health, Social, and Economic Costs of a Pandemic
-Version: 0.2.11
+Version: 0.2.12
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus 0.2.12
+
+This patch version adds a `response_duration` argument to `daedalus2()`, and tests for time-limited responses.
+
 # daedalus 0.2.11
 
 This patch version adds logging of new vaccinations in each age and economic group.

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -85,6 +85,9 @@ daedalus2_internal <- function(time_end, params, state, flags, ode_control) {
 #'
 #' @inheritParams daedalus
 #'
+#' @param response_duration A single integer-ish number that gives the number of
+#' days after `response_time` that an NPI should end.
+#'
 #' @param ... Optional arguments that are passed to [dust2::dust_ode_control()].
 #'
 #' @details
@@ -110,6 +113,7 @@ daedalus2 <- function(
   response_strategy = NULL,
   vaccine_investment = NULL,
   response_time = 30,
+  response_duration = 365,
   time_end = 100,
   ...
 ) {
@@ -191,11 +195,24 @@ daedalus2 <- function(
       response_time,
       upper = time_end - 2L, # for compat with daedalus
       lower = 1L, # responses cannot start at 0, unless strategy is null
-      any.missing = FALSE
+      any.missing = FALSE,
+      len = 1
     )
     if (!is_good_response_time) {
       cli::cli_abort(
         "Expected `response_time` to be between 1 and {time_end - 2L}."
+      )
+    }
+
+    is_good_response_duration <- checkmate::test_integerish(
+      response_duration,
+      lower = 0L, # no minimum duration
+      any.missing = FALSE,
+      len = 1
+    )
+    if (!is_good_response_duration) {
+      cli::cli_abort(
+        "Expected `response_duration` to be a single integer-like and >= 0"
       )
     }
   }
@@ -232,7 +249,8 @@ daedalus2 <- function(
       beta = get_beta(infection, country),
       susc = susc,
       openness = openness,
-      response_time = response_time
+      response_time = response_time,
+      response_duration = response_duration
     )
   )
 

--- a/R/dust.R
+++ b/R/dust.R
@@ -6,9 +6,9 @@ daedalus_ode <- structure(
   package = "daedalus",
   path = NULL,
   parameters = data.frame(
-    name = c("beta", "sigma", "p_sigma", "epsilon", "rho", "eta", "omega", "gamma_Ia", "gamma_Is", "gamma_H", "nu", "uptake_limit", "susc", "psi", "vax_start_time", "n_age_groups", "n_econ_groups", "popsize", "cm", "cm_work", "cm_cons_work", "hospital_capacity", "openness", "response_time"),
-    type = c("real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "int", "int", "int", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type"),
-    constant = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE)),
+    name = c("beta", "sigma", "p_sigma", "epsilon", "rho", "eta", "omega", "gamma_Ia", "gamma_Is", "gamma_H", "nu", "uptake_limit", "susc", "psi", "vax_start_time", "n_age_groups", "n_econ_groups", "popsize", "cm", "cm_work", "cm_cons_work", "hospital_capacity", "openness", "response_time", "response_duration"),
+    type = c("real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "int", "int", "int", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type"),
+    constant = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE)),
   properties = list(
     time_type = "continuous",
     has_compare = FALSE,

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -71,6 +71,7 @@ using TensorAry = daedalus::types::TensorAry<double>;
 // [[dust2::parameter(hospital_capacity, type = "real_type", constant = TRUE)]]
 // [[dust2::parameter(openness, constant = TRUE)]]
 // [[dust2::parameter(response_time, constant = TRUE)]]
+// [[dust2::parameter(response_duration, constant = TRUE)]]
 class daedalus_ode {
  public:
   daedalus_ode() = delete;
@@ -243,6 +244,9 @@ class daedalus_ode {
     // this is used to set hosp capacity to NAN so the response is not triggered
     const real_type response_time =
         dust2::r::read_real(pars, "response_time", NAN);
+    const real_type response_duration =
+        dust2::r::read_real(pars, "response_duration", NAN);
+
     // hospital capacity data
     const real_type hospital_capacity =
         std::isnan(response_time)
@@ -267,10 +271,10 @@ class daedalus_ode {
     std::vector<size_t> idx_hosp =
         daedalus::helpers::get_state_idx({iH + 1}, n_strata, N_VAX_STRATA);
 
-    // NOTE: no response end time specified for now; represented by 0.0
-    daedalus::events::response npi(std::string("npi"), response_time, 0.0,
-                                   hospital_capacity, gamma_Ia, i_npi_flag,
-                                   idx_hosp, i_ipr);
+    // NOTE: NPI response end time passed as parameter; vax end time remains 0.0
+    daedalus::events::response npi(
+        std::string("npi"), response_time, response_time + response_duration,
+        hospital_capacity, gamma_Ia, i_npi_flag, idx_hosp, i_ipr);
     daedalus::events::response vaccination(std::string("vaccination"),
                                            vax_start_time, 0.0, 0.0, 0.0,
                                            i_vax_flag, {0}, 0);

--- a/man/daedalus2.Rd
+++ b/man/daedalus2.Rd
@@ -10,6 +10,7 @@ daedalus2(
   response_strategy = NULL,
   vaccine_investment = NULL,
   response_time = 30,
+  response_duration = 365,
   time_end = 100,
   ...
 )
@@ -55,6 +56,9 @@ Other accepted values are \code{"low"}, \code{"medium"} and \code{"high"}. See
 at which the selected response is activated. This is ignored if the response
 has already been activated by the hospitalisation threshold being reached.
 Defaults to 30 days.}
+
+\item{response_duration}{A single integer-ish number that gives the number of
+days after \code{response_time} that an NPI should end.}
 
 \item{time_end}{An integer-like value for the number of timesteps
 at which to return data. This is treated as the number of days with data

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -73,6 +73,7 @@ using TensorAry = daedalus::types::TensorAry<double>;
 // [[dust2::parameter(hospital_capacity, type = "real_type", constant = TRUE)]]
 // [[dust2::parameter(openness, constant = TRUE)]]
 // [[dust2::parameter(response_time, constant = TRUE)]]
+// [[dust2::parameter(response_duration, constant = TRUE)]]
 class daedalus_ode {
  public:
   daedalus_ode() = delete;
@@ -245,6 +246,9 @@ class daedalus_ode {
     // this is used to set hosp capacity to NAN so the response is not triggered
     const real_type response_time =
         dust2::r::read_real(pars, "response_time", NAN);
+    const real_type response_duration =
+        dust2::r::read_real(pars, "response_duration", NAN);
+
     // hospital capacity data
     const real_type hospital_capacity =
         std::isnan(response_time)
@@ -269,10 +273,10 @@ class daedalus_ode {
     std::vector<size_t> idx_hosp =
         daedalus::helpers::get_state_idx({iH + 1}, n_strata, N_VAX_STRATA);
 
-    // NOTE: no response end time specified for now; represented by 0.0
-    daedalus::events::response npi(std::string("npi"), response_time, 0.0,
-                                   hospital_capacity, gamma_Ia, i_npi_flag,
-                                   idx_hosp, i_ipr);
+    // NOTE: NPI response end time passed as parameter; vax end time remains 0.0
+    daedalus::events::response npi(
+        std::string("npi"), response_time, response_time + response_duration,
+        hospital_capacity, gamma_Ia, i_npi_flag, idx_hosp, i_ipr);
     daedalus::events::response vaccination(std::string("vaccination"),
                                            vax_start_time, 0.0, 0.0, 0.0,
                                            i_vax_flag, {0}, 0);

--- a/tests/testthat/test-daedalus2_events.R
+++ b/tests/testthat/test-daedalus2_events.R
@@ -32,6 +32,46 @@ test_that("daedalus2: root-finding events launch at each appropriate root", {
   )
 })
 
+test_that("daedalus2: setting response duration works", {
+  response_time <- 10
+  response_duration <- 30
+  output <- daedalus2(
+    "GBR",
+    "sars_cov_1",
+    "elimination",
+    response_time = response_time,
+    response_duration = response_duration
+  )
+
+  expect_identical(
+    output$response_data$closure_info$closure_time_end,
+    response_time + response_duration
+  )
+
+  # check that response duration of 0 is the same as no response
+  # must set hospital capacity to prevent event based triggering
+  cx <- daedalus_country("GBR")
+  cx$hospital_capacity <- 1e9
+  response_time <- 10
+  response_duration <- 0
+  output_alt <- daedalus2(
+    cx,
+    "sars_cov_1",
+    "elimination",
+    response_time = response_time,
+    response_duration = response_duration
+  )
+  output <- daedalus2(
+    cx,
+    "sars_cov_1"
+  )
+
+  expect_identical(
+    get_epidemic_summary(output_alt, "infections"),
+    get_epidemic_summary(output, "infections")
+  )
+})
+
 # NOTE: this test will/should be reinstated when daedalus2() replaces daedalus()
 skip("Full event data is no longer returned for compliance with output class")
 test_that("Vaccination events launch as expected", {

--- a/tests/testthat/test-equivalence.R
+++ b/tests/testthat/test-equivalence.R
@@ -21,6 +21,7 @@ test_that("daedalus() and daedalus2() are equivalent", {
     x,
     response_strategy = "elimination",
     response_time = 2,
+    response_duration = 400,
     time_end = 399
   ) # one less timestep
   output_daedalus <- daedalus(


### PR DESCRIPTION
This PR version adds a `response_duration` argument to `daedalus2()`, and tests for time-limited responses.

The default value is set to 365; this comes from discussions around the time of the IDM workshop.