### PR TITLE
Replace `daedalus()` with `daedalus2()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus
 Title: Model Health, Social, and Economic Costs of a Pandemic
-Version: 0.2.12
+Version: 0.2.13
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus 0.2.13
+
+This patch version replaces all calls to `daedalus()` with `daedalus2()`; this excludes equivalence tests. Some tests have been updated to conform to the function signature of `daedalus2()`; this is mostly related to how the NPI triggering  hospital threshold is passed to the function.
+
 # daedalus 0.2.12
 
 This patch version adds a `response_duration` argument to `daedalus2()`, and tests for time-limited responses.

--- a/R/class_country.R
+++ b/R/class_country.R
@@ -25,7 +25,7 @@ new_daedalus_country <- function(name, parameters) {
 #' @rdname class_country
 #'
 #' @description Helper functions to create and work with S3 class
-#' `<daedalus_country>` objects for use with [daedalus()].
+#' `<daedalus_country>` objects for use with [daedalus2()].
 #' These objects store country parameters for reuse and have methods for easy
 #' parameter access and editing, as well as processing raw country
 #' characteristics for the DAEDALUS model.

--- a/R/class_infection.R
+++ b/R/class_infection.R
@@ -25,7 +25,7 @@ new_daedalus_infection <- function(name, parameters) {
 #' @rdname class_infection
 #'
 #' @description Helper functions to create and work with S3 class
-#' `<daedalus_infection>` objects for use with [daedalus()].
+#' `<daedalus_infection>` objects for use with [daedalus2()].
 #' These objects store infection parameters for reuse and have methods for easy
 #' parameter access and editing, as well as processing raw infection
 #' characteristics for the DAEDALUS model.

--- a/R/class_vaccination.R
+++ b/R/class_vaccination.R
@@ -26,7 +26,7 @@ new_daedalus_vaccination <- function(name, parameters) {
 #' @rdname class_vaccination
 #'
 #' @description Helper functions to create and work with S3 class
-#' `<daedalus_vaccination>` objects for use with [daedalus()].
+#' `<daedalus_vaccination>` objects for use with [daedalus2()].
 #' These objects store vaccination parameters for reuse and have methods for
 #' easy parameter access and editing, as well as processing raw vaccination
 #' characteristics for the DAEDALUS model.
@@ -43,7 +43,7 @@ new_daedalus_vaccination <- function(name, parameters) {
 #'
 #' @param rate A single number for the _percentage_ of the total population that
 #' can be vaccinated each day. This is converted into a proportion automatically
-#' within [daedalus()].
+#' within [daedalus2()].
 #'
 #' @param uptake_limit A single number giving the upper limit for the
 #' _percentage_ of the population that can be vaccinated. When this limit is

--- a/R/costs.R
+++ b/R/costs.R
@@ -1,6 +1,6 @@
 #' Get epidemic costs from a DAEDALUS model run
 #'
-#' @param x A `<daedalus_output>` object from a call to [daedalus()].
+#' @param x A `<daedalus_output>` object from a call to [daedalus2()].
 #' @param summarise_as A string from among "none", "total", or "domain", for how
 #' the costs should be returned. Select "none", the default, for the raw costs
 #' along with overall and domain-specific totals; "total" for the overall cost,
@@ -44,7 +44,7 @@
 #' adjustment is applied.
 #'
 #' @examples
-#' output <- daedalus("Canada", "influenza_1918")
+#' output <- daedalus2("Canada", "influenza_1918")
 #'
 #' get_costs(output)
 #' @export

--- a/R/daedalus.R
+++ b/R/daedalus.R
@@ -83,7 +83,7 @@
 #'
 #' @examples
 #' # country and infection specified by strings using default characteristics
-#' output <- daedalus(
+#' output <- daedalus2(
 #'   "Canada", "influenza_1918"
 #' )
 #'
@@ -92,16 +92,16 @@
 #'   "Canada",
 #'   parameters = list(contact_matrix = matrix(5, 4, 4)) # uniform contacts
 #' )
-#' output <- daedalus(country_x, "influenza_1918")
+#' output <- daedalus2(country_x, "influenza_1918")
 #'
 #' # with some infection parameters over-ridden by the user
-#' output <- daedalus(
+#' output <- daedalus2(
 #'   "United Kingdom",
 #'   daedalus_infection("influenza_1918", r0 = 1.3)
 #' )
 #'
 #' # with default initial conditions over-ridden by the user
-#' output <- daedalus(
+#' output <- daedalus2(
 #'   "United Kingdom", "influenza_1918",
 #'   initial_state_manual = list(p_infectious = 1e-3)
 #' )

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -79,7 +79,7 @@ daedalus2_internal <- function(time_end, params, state, flags, ode_control) {
 
 #' DAEDALUS model implemented with dust
 #'
-#' `daedalus::daedalus2()` will eventually replace `daedalus::daedalus2()` with
+#' `daedalus::daedalus2()` will eventually replace `daedalus::daedalus()` with
 #' the model implemented in C++ to integrate with \pkg{dust2}
 #' (and in future \pkg{dust}). *This is a work in progress!*
 #'
@@ -93,7 +93,7 @@ daedalus2_internal <- function(time_end, params, state, flags, ode_control) {
 #' @details
 #' **Note that** `daedalus2()` currently uses a default vaccination strategy of
 #' _no vaccination_, using the internal helper function [dummy_vaccination()].
-#' This is expected to become the default for [daedalus2()] when it is replaced
+#' This is expected to become the default for [daedalus()] when it is replaced
 #' with `daedalus2()`.
 #'
 #' **Note also** that `daedalus2()` vaccination begins at the model start time,

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -79,7 +79,7 @@ daedalus2_internal <- function(time_end, params, state, flags, ode_control) {
 
 #' DAEDALUS model implemented with dust
 #'
-#' `daedalus::daedalus2()` will eventually replace `daedalus::daedalus()` with
+#' `daedalus::daedalus2()` will eventually replace `daedalus::daedalus2()` with
 #' the model implemented in C++ to integrate with \pkg{dust2}
 #' (and in future \pkg{dust}). *This is a work in progress!*
 #'
@@ -93,7 +93,7 @@ daedalus2_internal <- function(time_end, params, state, flags, ode_control) {
 #' @details
 #' **Note that** `daedalus2()` currently uses a default vaccination strategy of
 #' _no vaccination_, using the internal helper function [dummy_vaccination()].
-#' This is expected to become the default for [daedalus()] when it is replaced
+#' This is expected to become the default for [daedalus2()] when it is replaced
 #' with `daedalus2()`.
 #'
 #' **Note also** that `daedalus2()` vaccination begins at the model start time,

--- a/R/daedalus2.R
+++ b/R/daedalus2.R
@@ -114,7 +114,8 @@ daedalus2 <- function(
   vaccine_investment = NULL,
   response_time = 30,
   response_duration = 365,
-  time_end = 100,
+  initial_state_manual = NULL,
+  time_end = 600,
   ...
 ) {
   # prepare flags
@@ -144,6 +145,7 @@ daedalus2 <- function(
   # also prepare the appropriate economic openness vectors
   # allowing for a numeric vector, or NULL for truly no response
   if (is.null(response_strategy)) {
+    response_strategy <- "none" # for output class
     openness <- rep(1.0, N_ECON_SECTORS)
     response_time <- NULL # to be filtered out later
   } else if (is.numeric(response_strategy)) {
@@ -190,7 +192,8 @@ daedalus2 <- function(
     vaccine_investment <- daedalus_vaccination(vaccine_investment)
   }
 
-  if (!(is.null(response_strategy) || response_strategy == "none")) {
+  # NULL converted to "none"; WIP: this will be moved to a class constructor
+  if (response_strategy != "none") {
     is_good_response_time <- checkmate::test_integerish(
       response_time,
       upper = time_end - 2L, # for compat with daedalus
@@ -226,7 +229,7 @@ daedalus2 <- function(
   }
 
   #### Prepare initial state and parameters ####
-  initial_state <- as.vector(make_initial_state2(country))
+  initial_state <- as.vector(make_initial_state2(country, initial_state_manual))
 
   # add state for new vaccinations by age group and econ sector
   state_new_vax <- numeric(

--- a/R/model_helpers.R
+++ b/R/model_helpers.R
@@ -72,34 +72,40 @@ make_consumer_contacts <- function(country) {
 make_initial_state <- function(country, initial_state_manual) {
   # NOTE: country checked in daedalus()
   initial_infect_state <- list(p_infectious = 1e-6, p_asymptomatic = 0.0)
-  initial_infect_state[names(initial_state_manual)] <- initial_state_manual
 
-  p_infectious <- initial_infect_state[["p_infectious"]]
-  p_asymptomatic <- initial_infect_state[["p_asymptomatic"]]
+  if (is.null(initial_state_manual)) {
+    p_infectious <- initial_infect_state[["p_infectious"]]
+    p_asymptomatic <- initial_infect_state[["p_asymptomatic"]]
+  } else {
+    initial_infect_state[names(initial_state_manual)] <- initial_state_manual
 
-  # NOTE: no checks on country as this is tested in top-level fn `daedalus()`
-  # check other inputs
-  is_good_p_infectious <- checkmate::test_number(
-    p_infectious,
-    lower = 0.0,
-    upper = 1.0
-  )
-  if (!is_good_p_infectious) {
-    cli::cli_abort(
-      "`p_infectious` must be a single number in the range [0.0, 1.0].",
-      .envir = parent.frame()
+    p_infectious <- initial_infect_state[["p_infectious"]]
+    p_asymptomatic <- initial_infect_state[["p_asymptomatic"]]
+
+    # NOTE: no checks on country as this is tested in top-level fn `daedalus()`
+    # check other inputs
+    is_good_p_infectious <- checkmate::test_number(
+      p_infectious,
+      lower = 0.0,
+      upper = 1.0
     )
-  }
+    if (!is_good_p_infectious) {
+      cli::cli_abort(
+        "`p_infectious` must be a single number in the range [0.0, 1.0].",
+        .envir = parent.frame()
+      )
+    }
 
-  is_good_p_asymp <- checkmate::test_number(
-    p_asymptomatic,
-    lower = 0.0,
-    upper = 1.0
-  )
-  if (!is_good_p_asymp) {
-    cli::cli_abort(
-      "`p_asymptomatic` must be a single number in the range [0.0, 1.0]."
+    is_good_p_asymp <- checkmate::test_number(
+      p_asymptomatic,
+      lower = 0.0,
+      upper = 1.0
     )
+    if (!is_good_p_asymp) {
+      cli::cli_abort(
+        "`p_asymptomatic` must be a single number in the range [0.0, 1.0]."
+      )
+    }
   }
 
   initial_state <- c(

--- a/R/model_helpers.R
+++ b/R/model_helpers.R
@@ -70,7 +70,7 @@ make_consumer_contacts <- function(country) {
 #' vaccinations).
 #' @keywords internal
 make_initial_state <- function(country, initial_state_manual) {
-  # NOTE: country checked in daedalus()
+  # NOTE: country checked in daedalus2()
   initial_infect_state <- list(p_infectious = 1e-6, p_asymptomatic = 0.0)
 
   if (is.null(initial_state_manual)) {
@@ -82,7 +82,7 @@ make_initial_state <- function(country, initial_state_manual) {
     p_infectious <- initial_infect_state[["p_infectious"]]
     p_asymptomatic <- initial_infect_state[["p_asymptomatic"]]
 
-    # NOTE: no checks on country as this is tested in top-level fn `daedalus()`
+    # NOTE: no checks on country as this is tested in top-level fn `daedalus2()`
     # check other inputs
     is_good_p_infectious <- checkmate::test_number(
       p_infectious,

--- a/R/ode.R
+++ b/R/ode.R
@@ -7,10 +7,10 @@
 #' @param state Vector of the initial state. The form of the vector should be
 #' \eqn{X_i, for X \in S, E, I_s, I_a, R, H, D}, where values for each
 #' of the compartments for each age group \eqn{i} are given consecutively.
-#' May be a matrix to allow for multiple age groups. See [daedalus()] for an
+#' May be a matrix to allow for multiple age groups. See [daedalus2()] for an
 #' explanation of the epidemiological compartments.
 #' @param parameters List for the parameters used in the simulation. See
-#' [daedalus()] for a list of model parameters.
+#' [daedalus2()] for a list of model parameters.
 #' @return A list with a single numeric vector of the same size as `state`,
 #' suitable as output for \pkg{deSolve} functions such as [deSolve::lsoda()].
 #' @details

--- a/R/output_helpers.R
+++ b/R/output_helpers.R
@@ -3,9 +3,9 @@
 #' @name epi_output_helpers
 #' @rdname epi_output_helpers
 #'
-#' @description Functions to quickly summarise timeseries data from `daedalus2()`
-#' to provide daily values for infections, hospitalisations, deaths, and
-#' vaccinations, while allowing grouping by different strata.
+#' @description Functions to quickly summarise timeseries data from
+#' [daedalus2()] to provide daily values for infections, hospitalisations,
+#' deaths, and vaccinations, while allowing grouping by different strata.
 #'
 #' @param data Either a `<data.frame>` from a call to `get_data()` on a
 #' `<daedalus_output>` object, or such an object directly.

--- a/R/output_helpers.R
+++ b/R/output_helpers.R
@@ -3,7 +3,7 @@
 #' @name epi_output_helpers
 #' @rdname epi_output_helpers
 #'
-#' @description Functions to quickly summarise timeseries data from `daedalus()`
+#' @description Functions to quickly summarise timeseries data from `daedalus2()`
 #' to provide daily values for infections, hospitalisations, deaths, and
 #' vaccinations, while allowing grouping by different strata.
 #'
@@ -40,7 +40,7 @@
 #' Columns for the `groups` are added when `groups` are specified.
 #'
 #' @examples
-#' data <- daedalus("Canada", "sars_cov_1")
+#' data <- daedalus2("Canada", "sars_cov_1")
 #'
 #' # new infections
 #' new_infections <- get_incidence(data, "infections")

--- a/R/pkg_generics.R
+++ b/R/pkg_generics.R
@@ -29,7 +29,7 @@
 #' get_data(disease_x, "r0")
 #'
 #' # get model data
-#' output <- daedalus("Canada", "influenza_1918")
+#' output <- daedalus2("Canada", "influenza_1918")
 #' head(
 #'   get_data(output)
 #' )

--- a/R/prepare_output.R
+++ b/R/prepare_output.R
@@ -4,7 +4,7 @@
 #' @rdname prepare_output
 #'
 #' @description Convert DAEDALUS data into a long-format `<data.frame>`.
-#' @param output Output from [daedalus()] of the class `<deSolve>`.
+#' @param output Output from [daedalus2()] of the class `<deSolve>`.
 #' @return A `<data.frame>` in long or 'tidy' format with the columns
 #' "time", "age_group", "compartment", "econ_sector", and "value", for the
 #' age-group specific value of the number of individuals in each economic sector

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,7 +68,7 @@ This automatically pulls country-specific demographic and economic data, which i
 library(daedalus)
 
 # run model for Canada
-data <- daedalus("Canada", "influenza_1918")
+data <- daedalus2("Canada", "influenza_1918")
 
 # get pandemic costs as a total in million dollars
 get_costs(data, "total")
@@ -79,9 +79,9 @@ get_costs(data, "domain")
 
 Users can select infection parameters from among seven epidemics caused by directly-transmitted viral respiratory pathogens, which are stored in the stand-alone helper package `daedalus.data`. These can be called as `daedalus.data::infection_data`, while epidemic identifiers are stored as `daedalus.data::epidemic_names`.
 
-Users can override default country contact data and epidemic-specific infection arguments by passing custom classes to `daedalus()`; see the package website for more details.
+Users can override default country contact data and epidemic-specific infection arguments by passing custom classes to `daedalus2()`; see the package website for more details.
 
-Users can also model the implementation of pandemic response measures: for more on this see the documentation for the main model function `daedalus()`, and the vignette on modelling interventions on the package website.
+Users can also model the implementation of pandemic response measures: for more on this see the documentation for the main model function `daedalus2()`, and the vignette on modelling interventions on the package website.
 
 ## Related projects
 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ for more details).
 library(daedalus)
 
 # run model for Canada
-data <- daedalus("Canada", "influenza_1918")
+data <- daedalus2("Canada", "influenza_1918")
 
 # get pandemic costs as a total in million dollars
 get_costs(data, "total")
-#> [1] 1627703
+#> [1] 1200136
 
 # disaggregate total for economic, education, and health costs
 get_costs(data, "domain")
 #>     economic    education   life_value   life_years 
-#>    33787.966     2207.265  1591707.843 34564774.017
+#> 3.300219e+04 1.262964e+00 1.167133e+06 2.534491e+07
 ```
 
 Users can select infection parameters from among seven epidemics caused
@@ -94,13 +94,13 @@ the stand-alone helper package `daedalus.data`. These can be called as
 as `daedalus.data::epidemic_names`.
 
 Users can override default country contact data and epidemic-specific
-infection arguments by passing custom classes to `daedalus()`; see the
+infection arguments by passing custom classes to `daedalus2()`; see the
 package website for more details.
 
 Users can also model the implementation of pandemic response measures:
 for more on this see the documentation for the main model function
-`daedalus()`, and the vignette on modelling interventions on the package
-website.
+`daedalus2()`, and the vignette on modelling interventions on the
+package website.
 
 ## Related projects
 

--- a/man/class_country.Rd
+++ b/man/class_country.Rd
@@ -47,7 +47,7 @@ object \code{x}. Called for printing side-effects.
 }
 \description{
 Helper functions to create and work with S3 class
-\verb{<daedalus_country>} objects for use with \code{\link[=daedalus]{daedalus()}}.
+\verb{<daedalus_country>} objects for use with \code{\link[=daedalus2]{daedalus2()}}.
 These objects store country parameters for reuse and have methods for easy
 parameter access and editing, as well as processing raw country
 characteristics for the DAEDALUS model.

--- a/man/class_infection.Rd
+++ b/man/class_infection.Rd
@@ -36,7 +36,7 @@ object \code{x}. Called for printing side-effects.
 }
 \description{
 Helper functions to create and work with S3 class
-\verb{<daedalus_infection>} objects for use with \code{\link[=daedalus]{daedalus()}}.
+\verb{<daedalus_infection>} objects for use with \code{\link[=daedalus2]{daedalus2()}}.
 These objects store infection parameters for reuse and have methods for easy
 parameter access and editing, as well as processing raw infection
 characteristics for the DAEDALUS model.

--- a/man/class_vaccination.Rd
+++ b/man/class_vaccination.Rd
@@ -33,7 +33,7 @@ time is taken from the vaccination scenarios specified by \code{name}.}
 
 \item{rate}{A single number for the \emph{percentage} of the total population that
 can be vaccinated each day. This is converted into a proportion automatically
-within \code{\link[=daedalus]{daedalus()}}.}
+within \code{\link[=daedalus2]{daedalus2()}}.}
 
 \item{uptake_limit}{A single number giving the upper limit for the
 \emph{percentage} of the population that can be vaccinated. When this limit is
@@ -56,7 +56,7 @@ compartments can wane out of being vaccinated.}
 }
 \description{
 Helper functions to create and work with S3 class
-\verb{<daedalus_vaccination>} objects for use with \code{\link[=daedalus]{daedalus()}}.
+\verb{<daedalus_vaccination>} objects for use with \code{\link[=daedalus2]{daedalus2()}}.
 These objects store vaccination parameters for reuse and have methods for
 easy parameter access and editing, as well as processing raw vaccination
 characteristics for the DAEDALUS model.

--- a/man/daedalus.Rd
+++ b/man/daedalus.Rd
@@ -102,7 +102,7 @@ asymptomatic. Defaults to 0.0.
 }
 \examples{
 # country and infection specified by strings using default characteristics
-output <- daedalus(
+output <- daedalus2(
   "Canada", "influenza_1918"
 )
 
@@ -111,16 +111,16 @@ country_x <- daedalus_country(
   "Canada",
   parameters = list(contact_matrix = matrix(5, 4, 4)) # uniform contacts
 )
-output <- daedalus(country_x, "influenza_1918")
+output <- daedalus2(country_x, "influenza_1918")
 
 # with some infection parameters over-ridden by the user
-output <- daedalus(
+output <- daedalus2(
   "United Kingdom",
   daedalus_infection("influenza_1918", r0 = 1.3)
 )
 
 # with default initial conditions over-ridden by the user
-output <- daedalus(
+output <- daedalus2(
   "United Kingdom", "influenza_1918",
   initial_state_manual = list(p_infectious = 1e-3)
 )

--- a/man/daedalus2.Rd
+++ b/man/daedalus2.Rd
@@ -73,14 +73,14 @@ returned for each day. Defaults to 300 days.}
 \item{...}{Optional arguments that are passed to \code{\link[dust2:dust_ode_control]{dust2::dust_ode_control()}}.}
 }
 \description{
-\code{daedalus::daedalus2()} will eventually replace \code{daedalus::daedalus()} with
+\code{daedalus::daedalus2()} will eventually replace \code{daedalus::daedalus2()} with
 the model implemented in C++ to integrate with \pkg{dust2}
 (and in future \pkg{dust}). \emph{This is a work in progress!}
 }
 \details{
 \strong{Note that} \code{daedalus2()} currently uses a default vaccination strategy of
 \emph{no vaccination}, using the internal helper function \code{\link[=dummy_vaccination]{dummy_vaccination()}}.
-This is expected to become the default for \code{\link[=daedalus]{daedalus()}} when it is replaced
+This is expected to become the default for \code{\link[=daedalus2]{daedalus2()}} when it is replaced
 with \code{daedalus2()}.
 
 \strong{Note also} that \code{daedalus2()} vaccination begins at the model start time,

--- a/man/daedalus2.Rd
+++ b/man/daedalus2.Rd
@@ -73,14 +73,14 @@ returned for each day. Defaults to 300 days.}
 \item{...}{Optional arguments that are passed to \code{\link[dust2:dust_ode_control]{dust2::dust_ode_control()}}.}
 }
 \description{
-\code{daedalus::daedalus2()} will eventually replace \code{daedalus::daedalus2()} with
+\code{daedalus::daedalus2()} will eventually replace \code{daedalus::daedalus()} with
 the model implemented in C++ to integrate with \pkg{dust2}
 (and in future \pkg{dust}). \emph{This is a work in progress!}
 }
 \details{
 \strong{Note that} \code{daedalus2()} currently uses a default vaccination strategy of
 \emph{no vaccination}, using the internal helper function \code{\link[=dummy_vaccination]{dummy_vaccination()}}.
-This is expected to become the default for \code{\link[=daedalus2]{daedalus2()}} when it is replaced
+This is expected to become the default for \code{\link[=daedalus]{daedalus()}} when it is replaced
 with \code{daedalus2()}.
 
 \strong{Note also} that \code{daedalus2()} vaccination begins at the model start time,

--- a/man/daedalus2.Rd
+++ b/man/daedalus2.Rd
@@ -11,7 +11,8 @@ daedalus2(
   vaccine_investment = NULL,
   response_time = 30,
   response_duration = 365,
-  time_end = 100,
+  initial_state_manual = NULL,
+  time_end = 600,
   ...
 )
 }
@@ -59,6 +60,11 @@ Defaults to 30 days.}
 
 \item{response_duration}{A single integer-ish number that gives the number of
 days after \code{response_time} that an NPI should end.}
+
+\item{initial_state_manual}{An optional \strong{named} list with the names
+\code{p_infectious} and \code{p_asymptomatic} for the proportion of infectious and
+symptomatic individuals in each age group and economic sector.
+Defaults to \code{1e-6} and \code{0.0} respectively.}
 
 \item{time_end}{An integer-like value for the number of timesteps
 at which to return data. This is treated as the number of days with data

--- a/man/daedalus_rhs.Rd
+++ b/man/daedalus_rhs.Rd
@@ -12,11 +12,11 @@ daedalus_rhs(t, state, parameters)
 \item{state}{Vector of the initial state. The form of the vector should be
 \eqn{X_i, for X \in S, E, I_s, I_a, R, H, D}, where values for each
 of the compartments for each age group \eqn{i} are given consecutively.
-May be a matrix to allow for multiple age groups. See \code{\link[=daedalus]{daedalus()}} for an
+May be a matrix to allow for multiple age groups. See \code{\link[=daedalus2]{daedalus2()}} for an
 explanation of the epidemiological compartments.}
 
 \item{parameters}{List for the parameters used in the simulation. See
-\code{\link[=daedalus]{daedalus()}} for a list of model parameters.}
+\code{\link[=daedalus2]{daedalus2()}} for a list of model parameters.}
 }
 \value{
 A list with a single numeric vector of the same size as \code{state},

--- a/man/epi_output_helpers.Rd
+++ b/man/epi_output_helpers.Rd
@@ -55,12 +55,12 @@ Columns for the \code{groups} are added when \code{groups} are specified.
 }
 }
 \description{
-Functions to quickly summarise timeseries data from \code{daedalus()}
+Functions to quickly summarise timeseries data from \code{daedalus2()}
 to provide daily values for infections, hospitalisations, deaths, and
 vaccinations, while allowing grouping by different strata.
 }
 \examples{
-data <- daedalus("Canada", "sars_cov_1")
+data <- daedalus2("Canada", "sars_cov_1")
 
 # new infections
 new_infections <- get_incidence(data, "infections")

--- a/man/epi_output_helpers.Rd
+++ b/man/epi_output_helpers.Rd
@@ -55,9 +55,9 @@ Columns for the \code{groups} are added when \code{groups} are specified.
 }
 }
 \description{
-Functions to quickly summarise timeseries data from \code{daedalus2()}
-to provide daily values for infections, hospitalisations, deaths, and
-vaccinations, while allowing grouping by different strata.
+Functions to quickly summarise timeseries data from
+\code{\link[=daedalus2]{daedalus2()}} to provide daily values for infections, hospitalisations,
+deaths, and vaccinations, while allowing grouping by different strata.
 }
 \examples{
 data <- daedalus2("Canada", "sars_cov_1")

--- a/man/get_costs.Rd
+++ b/man/get_costs.Rd
@@ -7,7 +7,7 @@
 get_costs(x, summarise_as = c("none", "total", "domain"))
 }
 \arguments{
-\item{x}{A \verb{<daedalus_output>} object from a call to \code{\link[=daedalus]{daedalus()}}.}
+\item{x}{A \verb{<daedalus_output>} object from a call to \code{\link[=daedalus2]{daedalus2()}}.}
 
 \item{summarise_as}{A string from among "none", "total", or "domain", for how
 the costs should be returned. Select "none", the default, for the raw costs
@@ -59,7 +59,7 @@ adjustment is applied.
 }
 }
 \examples{
-output <- daedalus("Canada", "influenza_1918")
+output <- daedalus2("Canada", "influenza_1918")
 
 get_costs(output)
 }

--- a/man/get_data.Rd
+++ b/man/get_data.Rd
@@ -50,7 +50,7 @@ disease_x <- daedalus_infection("sars_cov_1", r0 = 1.9)
 get_data(disease_x, "r0")
 
 # get model data
-output <- daedalus("Canada", "influenza_1918")
+output <- daedalus2("Canada", "influenza_1918")
 head(
   get_data(output)
 )

--- a/man/prepare_output.Rd
+++ b/man/prepare_output.Rd
@@ -10,7 +10,7 @@ prepare_output(output)
 prepare_output_cpp(output, country)
 }
 \arguments{
-\item{output}{Output from \code{\link[=daedalus]{daedalus()}} of the class \verb{<deSolve>}.}
+\item{output}{Output from \code{\link[=daedalus2]{daedalus2()}} of the class \verb{<deSolve>}.}
 
 \item{country}{A \verb{<daedalus_country>} object from which to get data on the
 number of demographic, economic, and vaccine groups.}

--- a/tests/testthat/test-class_daedalus_country.R
+++ b/tests/testthat/test-class_daedalus_country.R
@@ -13,8 +13,8 @@ test_that("class <daedalus_country>: basic expectations", {
 
   # model function can handle either string or class input
   expect_identical(
-    daedalus("Canada", "influenza_1918"),
-    daedalus(daedalus_country("Canada"), "influenza_1918"),
+    daedalus2("Canada", "influenza_1918"),
+    daedalus2(daedalus_country("Canada"), "influenza_1918"),
     tolerance = 1e-6
   )
 })

--- a/tests/testthat/test-class_daedalus_infection.R
+++ b/tests/testthat/test-class_daedalus_infection.R
@@ -13,8 +13,8 @@ test_that("class <daedalus_infection>: basic expectations", {
 
   # model function can handle either string or class input
   expect_identical(
-    daedalus("Canada", "influenza_1918"),
-    daedalus("Canada", daedalus_infection("influenza_1918"))
+    daedalus2("Canada", "influenza_1918"),
+    daedalus2("Canada", daedalus_infection("influenza_1918"))
   )
 })
 

--- a/tests/testthat/test-class_daedalus_output.R
+++ b/tests/testthat/test-class_daedalus_output.R
@@ -1,7 +1,7 @@
 # Tests for the <daedalus_output> class
 test_that("class <daedalus_output>: basic expectations", {
   expect_no_condition({
-    output <- daedalus("Canada", "influenza_1918") # nolint saves assignment
+    output <- daedalus2("Canada", "influenza_1918") # nolint saves assignment
   })
   expect_s3_class(output, "daedalus_output")
   checkmate::expect_list(

--- a/tests/testthat/test-class_daedalus_vaccination.R
+++ b/tests/testthat/test-class_daedalus_vaccination.R
@@ -25,14 +25,14 @@ test_that("class <daedalus_vaccination>: basic expectations", {
   checkmate::expect_list(x, c("character", "numeric"), any.missing = FALSE)
 
   # model function can handle either string or class input
-  data_string <- daedalus(
+  data_string <- daedalus2(
     "Canada",
     "influenza_1918",
     vaccine_investment = "medium"
   )
   data_string <- get_new_vaccinations(data_string)
 
-  data_s3 <- daedalus(
+  data_s3 <- daedalus2(
     "Canada",
     "influenza_1918",
     vaccine_investment = daedalus_vaccination("medium")

--- a/tests/testthat/test-closures.R
+++ b/tests/testthat/test-closures.R
@@ -11,7 +11,7 @@ test_that("Closures: basic expectations: runs without errors", {
   # test all responses
   expect_no_condition({
     output_list <- lapply(response_names, function(x) {
-      daedalus(country_x, "sars_cov_1", response_strategy = x)
+      daedalus2(country_x, "sars_cov_1", response_strategy = x)
     })
   })
 
@@ -21,7 +21,7 @@ test_that("Closures: basic expectations: runs without errors", {
       response_names,
       daedalus.data::country_names[seq_along(response_names)],
       f = function(response, country) {
-        expect_no_condition(daedalus(
+        expect_no_condition(daedalus2(
           country,
           "sars_cov_1",
           response_strategy = response
@@ -34,10 +34,12 @@ test_that("Closures: basic expectations: runs without errors", {
 # expect that applying closures reduces epidemic size
 test_that("Closures: basic statistical correctness: reduces epidemic size", {
   output_list <- lapply(response_names, function(x) {
-    daedalus(
+    daedalus2(
       country_x,
       daedalus_infection("sars_cov_1", rho = 0.0),
-      response_strategy = x
+      response_strategy = x,
+      response_time = 10,
+      time_end = 100
     )
   })
 
@@ -55,14 +57,14 @@ test_that("Closures: basic statistical correctness: reduces epidemic size", {
 # expect that earlier closures reduce epidemic size
 test_that("Closures: earlier closures reduce epidemic size", {
   response_times <- c(200, 30)
-  response_threshold <- 1e9 # very high to prevent auto-activation
+  cx <- country_x
+  cx$hospital_capacity <- 1e9
   output_list <- lapply(response_times, function(x) {
-    daedalus(
-      country_x,
+    daedalus2(
+      cx,
       daedalus_infection("sars_cov_1", rho = 0.0),
       response_strategy = "elimination",
-      response_time = x,
-      response_threshold = response_threshold
+      response_time = x
     )
   })
 
@@ -83,11 +85,13 @@ test_that("Closures: lower threshold reduces epidemic size", {
   # seems non-linear --- will open an issue for this
   response_thresholds <- c(1e7, 100)
   output_list <- lapply(response_thresholds, function(x) {
-    daedalus(
-      country_x,
+    cx <- country_x
+    cx$hospital_capacity <- x
+
+    daedalus2(
+      cx,
       daedalus_infection("sars_cov_1", rho = 0.0),
       response_strategy = "elimination",
-      response_threshold = x,
       response_time = 200 # artificially high
     )
   })
@@ -107,15 +111,15 @@ test_that("Closures: lower threshold reduces epidemic size", {
 # NOTE: we can only really test closure start times, as closures either
 # end reactively or do not end at all
 test_that("Closures: correct logging of time limits", {
-  response_threshold <- 1e9 # artificially large
+  cx <- country_x
+  cx$hospital_capacity <- 1e9
   response_time <- 10 # arbitrary value
   time_end <- 25 # low to prematurely end simulation
   dummy_vax <- daedalus_vaccination("none", start_time = 15)
-  output <- daedalus(
-    "Thailand",
+  output <- daedalus2(
+    cx,
     daedalus_infection("influenza_1918", r0 = 1.1),
     response_strategy = "elimination",
-    response_threshold = response_threshold,
     response_time = response_time,
     vaccine_investment = dummy_vax,
     time_end = time_end
@@ -131,22 +135,25 @@ test_that("Closures: correct logging of time limits", {
     response_data[["closure_info"]][["closure_time_end"]],
     time_end
   )
+})
 
+skip("Event termination on state not yet implemented.")
+test_that("NPIs terminate at start time when epidemic is not growing", {
   # Check that closures are terminated at the start time when
   # the epidemic is not growing
-  dvx <- daedalus_vaccination("low", start_time = 90)
   tend <- 100
   response_time <- seq(10, 80, 10)
 
   # run scenario with very few susceptibles
+  cx <- country_x
+  cx$hospital_capacity <- 1e9
   invisible(lapply(response_time, function(x) {
-    data <- daedalus(
-      "United States",
+    data <- daedalus2(
+      cx,
       "influenza_1957",
       initial_state_manual = list(p_infectious = 0.9999),
       response_strategy = "elimination",
       response_time = x,
-      vaccine_investment = dvx,
       time_end = tend
     )
 

--- a/tests/testthat/test-costs.R
+++ b/tests/testthat/test-costs.R
@@ -1,6 +1,6 @@
 # Tests on model cost function
 test_that("Costs: basic expectations", {
-  output <- daedalus("Canada", "influenza_1918")
+  output <- daedalus2("Canada", "influenza_1918")
   expect_no_condition({
     costs <- get_costs(output)
   })
@@ -36,7 +36,7 @@ test_that("Costs: basic expectations", {
 
 test_that("Costs: scenario expectations", {
   ## when response = "none"
-  output <- daedalus("Canada", "influenza_2009", time_end = 400)
+  output <- daedalus2("Canada", "influenza_2009", time_end = 400)
   costs <- get_costs(output)
 
   expect_identical(costs$economic_costs$economic_cost_closures, 0)
@@ -47,7 +47,7 @@ test_that("Costs: scenario expectations", {
 
   o <- lapply(
     x,
-    daedalus,
+    daedalus2,
     country = "United Kingdom",
     infection = "influenza_1957",
     response_time = 10
@@ -63,7 +63,7 @@ test_that("Costs: scenario expectations", {
   response_names <- c("elimination", "economic_closures", "school_closures")
   invisible({
     lapply(response_names, function(x) {
-      output <- daedalus("Canada", "influenza_1918", response_strategy = x)
+      output <- daedalus2("Canada", "influenza_1918", response_strategy = x)
       costs <- get_costs(output)
 
       # closure costs must be at least one day of reduced GVA
@@ -86,7 +86,7 @@ test_that("Expectations on schooling costs", {
 
   o <- lapply(
     x,
-    daedalus,
+    daedalus2,
     country = "United Kingdom",
     infection = daedalus_infection("sars_cov_1")
   )

--- a/tests/testthat/test-daedalus2.R
+++ b/tests/testthat/test-daedalus2.R
@@ -143,7 +143,7 @@ test_that("daedalus2: Runs for all country x infection x response", {
 
 # test that passing model parameters works
 test_that("daedalus: Passing model parameters", {
-  expect_no_condition(daedalus(
+  expect_no_condition(daedalus2(
     country_canada,
     daedalus_infection("influenza_1918", r0 = 1.3, eta = c(0.1, 0.2, 0.3, 0.4))
   ))

--- a/tests/testthat/test-equivalence.R
+++ b/tests/testthat/test-equivalence.R
@@ -14,15 +14,14 @@ test_that("daedalus() and daedalus2() are equivalent", {
   )
 
   # get outputs
-  # NOTE: response specified as 'none' rather than NULL because `daedalus()`
-  # triggers public-concern distancing even when response is 'none'
   output_daedalus2 <- daedalus2(
     ct,
     x,
     response_strategy = "elimination",
     response_time = 2,
     response_duration = 400,
-    time_end = 399
+    time_end = 399,
+    initial_state_manual = list(p_infectious = 1e-7)
   ) # one less timestep
   output_daedalus <- daedalus(
     ct,

--- a/tests/testthat/test-hospital_capacity.R
+++ b/tests/testthat/test-hospital_capacity.R
@@ -3,12 +3,13 @@
 test_that("Hospital capacity: basic expectations", {
   # NOTE: Not testing every country and infection
   response_strategy <- c("elimination", "school_closures", "economic_closures")
+  cx <- daedalus_country("China")
+  cx$hospital_capacity <- 100L
   invisible(lapply(response_strategy, function(x) {
     expect_no_condition({
-      daedalus(
-        country = "China",
+      daedalus2(
+        country = cx,
         infection = "influenza_1918",
-        response_threshold = 100L,
         response_strategy = x
       )
     })
@@ -24,13 +25,13 @@ test_that("Closures: hospital capacity and closure time", {
   cty_y <- daedalus_country("Canada")
   cty_y$hospital_capacity <- round(cty_y$hospital_capacity * 2)
 
-  x <- daedalus(
+  x <- daedalus2(
     cty_x,
     "sars_cov_1",
     response_strategy = "elimination",
     response_time = 298
   )
-  y <- daedalus(
+  y <- daedalus2(
     cty_y,
     "sars_cov_1",
     response_strategy = "elimination",
@@ -42,12 +43,12 @@ test_that("Closures: hospital capacity and closure time", {
     y$response_data$closure_info$closure_time_start
   )
 
-  # hospital capacity override from `daedalus()`
-  x <- daedalus(
+  # hospital capacity override from `daedalus2()`
+  cty_x$hospital_capacity <- cty_y$hospital_capacity * 2 # 4x higher
+  x <- daedalus2(
     cty_x,
     "sars_cov_1",
     response_strategy = "elimination",
-    response_threshold = cty_y$hospital_capacity * 2, # 4x higher
     response_time = 298
   )
 

--- a/tests/testthat/test-model_helpers.R
+++ b/tests/testthat/test-model_helpers.R
@@ -2,7 +2,7 @@
 country_canada <- daedalus_country("Canada")
 test_that("Initial state preparation:", {
   expect_error(
-    daedalus(
+    daedalus2(
       country_canada,
       "influenza_1918",
       initial_state_manual = list(p_infectious = "0.1")
@@ -10,7 +10,7 @@ test_that("Initial state preparation:", {
     regexp = "must be a single number in the range \\[0.0, 1.0\\]"
   )
   expect_error(
-    daedalus(
+    daedalus2(
       country_canada,
       "influenza_1918",
       initial_state_manual = list(p_infectious = -0.1)
@@ -18,7 +18,7 @@ test_that("Initial state preparation:", {
     regexp = "(p_infectious)*(single number in the range \\[0.0, 1.0\\])"
   )
   expect_error(
-    daedalus(
+    daedalus2(
       country_canada,
       "influenza_1918",
       initial_state_manual = list(p_infectious = 1.0001)
@@ -26,7 +26,7 @@ test_that("Initial state preparation:", {
     regexp = "(p_infectious)*(single number in the range \\[0.0, 1.0\\])"
   )
   expect_error(
-    daedalus(
+    daedalus2(
       country_canada,
       "influenza_1918",
       initial_state_manual = list(p_infectious = c(0.1, 0.5))
@@ -35,7 +35,7 @@ test_that("Initial state preparation:", {
   )
 
   expect_error(
-    daedalus(
+    daedalus2(
       country_canada,
       "influenza_1918",
       initial_state_manual = list(p_asymptomatic = "0.1")
@@ -43,7 +43,7 @@ test_that("Initial state preparation:", {
     regexp = "(p_asymptomatic)*(single number in the range \\[0.0, 1.0\\])"
   )
   expect_error(
-    daedalus(
+    daedalus2(
       country_canada,
       "influenza_1918",
       initial_state_manual = list(p_asymptomatic = -1)
@@ -51,7 +51,7 @@ test_that("Initial state preparation:", {
     regexp = "(p_asymptomatic)*(single number in the range \\[0.0, 1.0\\])"
   )
   expect_error(
-    daedalus(
+    daedalus2(
       country_canada,
       "influenza_1918",
       initial_state_manual = list(p_asymptomatic = 1.00001)
@@ -59,7 +59,7 @@ test_that("Initial state preparation:", {
     regexp = "(p_asymptomatic)*(single number in the range \\[0.0, 1.0\\])"
   )
   expect_error(
-    daedalus(
+    daedalus2(
       country_canada,
       "influenza_1918",
       initial_state_manual = list(p_asymptomatic = c(0.1, 0.5))

--- a/tests/testthat/test-output_helpers.R
+++ b/tests/testthat/test-output_helpers.R
@@ -2,7 +2,7 @@
 # Test `get_new_infections()`
 test_that("Daily incidence: basic expectations", {
   country <- daedalus_country("Canada")
-  data <- daedalus(country, "sars_cov_1")
+  data <- daedalus2(country, "sars_cov_1")
 
   expect_no_condition({
     incidence <- get_incidence(data)
@@ -24,7 +24,7 @@ test_that("Daily incidence: basic expectations", {
 
 test_that("Epidemic summary: basic expectations", {
   country <- daedalus_country("Canada")
-  data <- daedalus(country, daedalus_infection("sars_cov_1", rho = 0))
+  data <- daedalus2(country, daedalus_infection("sars_cov_1", rho = 0))
 
   expect_no_condition({
     data_summary <- get_epidemic_summary(data)
@@ -57,7 +57,7 @@ test_that("New vaccinations: basic expectations", {
   vaccine_level <- daedalus_vaccination("medium")
   vax_time <- get_data(vaccine_level, "start_time")
   time_end <- 600
-  data <- daedalus(
+  data <- daedalus2(
     "Canada",
     daedalus_infection("sars_cov_1", rho = 0.0),
     vaccine_investment = vaccine_level,
@@ -78,11 +78,11 @@ test_that("New vaccinations: basic expectations", {
     groups = c("age_group", "vaccine_group")
   ))
 
-  # check that the first vaccinations start at vax_time + 1
+  # check that the first vaccinations start at vax_time + 2
   new_vax <- get_new_vaccinations(data)$new_vaccinations
 
   # equivalency expectation due to integer/double comparison
-  expect_equal(min(which(new_vax > 0)), vax_time + 1L, ignore_attr = TRUE)
+  expect_equal(min(which(new_vax > 0)), vax_time + 2L, ignore_attr = TRUE)
 
   # check new vaccinations is always positive
   expect_gte(min(new_vax), 0.0)
@@ -90,6 +90,6 @@ test_that("New vaccinations: basic expectations", {
     new_vax,
     finite = TRUE,
     any.missing = FALSE,
-    len = time_end
+    len = time_end + 1
   )
 })

--- a/tests/testthat/test-vaccination.R
+++ b/tests/testthat/test-vaccination.R
@@ -1,8 +1,8 @@
-# Tests for daedalus() with vaccination active
+# Tests for daedalus2() with vaccination active
 test_that("Vaccination: basic expectations", {
   vax_level <- daedalus_vaccination("medium")
   expect_no_condition({
-    output <- daedalus("Canada", "sars_cov_1", vaccine_investment = vax_level)
+    output <- daedalus2("Canada", "sars_cov_1", vaccine_investment = vax_level)
   })
   data <- get_data(output)
 

--- a/touchstone/script.R
+++ b/touchstone/script.R
@@ -8,20 +8,9 @@
 # installs branches to benchmark
 touchstone::branch_install()
 
-# benchmark daedalus::daedalus()
-touchstone::benchmark_run(
-  test_daedalus = daedalus::daedalus("GBR", "influenza_2009", "elimination"),
-  n = 10
-)
-
 # benchmark daedalus::daedalus2()
 touchstone::benchmark_run(
-  test_daedalus2 = daedalus::daedalus2(
-    "GBR",
-    "influenza_2009",
-    "elimination",
-    time_end = 600
-  ),
+  test_daedalus = daedalus::daedalus("GBR", "influenza_2009", "elimination"),
   n = 10
 )
 

--- a/vignettes/daedalus-two.Rmd
+++ b/vignettes/daedalus-two.Rmd
@@ -24,12 +24,12 @@ This vignette is intended as a visual check on _daedalus_ features in developmen
 
 ## Basic `daedalus2()` usage
 
-This example shows (checks) that `daedalus2()` output works with pre-built function `get_incidence()` written for `daedalus()`.
+This example shows (checks) that `daedalus2()` output works with pre-built function `get_incidence()` written for `daedalus2()`.
 
 ```{r}
 output <- daedalus2("GBR", "influenza_2009")
 
-# get incidence data using function developed for daedalus()
+# get incidence data using function developed for daedalus2()
 data <- get_incidence(output, "infections")
 
 ggplot(data) +

--- a/vignettes/daedalus.Rmd
+++ b/vignettes/daedalus.Rmd
@@ -26,7 +26,7 @@ library(ggplot2)
 
 ## Representing countries and territories
 
-The model can be run for any country or territory included in package data simply by passing its name to `daedalus()`.
+The model can be run for any country or territory included in package data simply by passing its name to `daedalus2()`.
 The `country_names` vector holds a list of country and territory names for which data is available.
 
 Passing the country name directly leads to the model accessing country characteristics stored as package data.
@@ -64,11 +64,11 @@ Epidemics with associated infection parameters are given in the package dependen
 daedalus.data::epidemic_names
 ```
 
-Users can pass the epidemic names directly to `daedalus()` to use the default infection parameters.
+Users can pass the epidemic names directly to `daedalus2()` to use the default infection parameters.
 
 ```r
 # not run
-output <- daedalus("Canada", "influenza_1918")
+output <- daedalus2("Canada", "influenza_1918")
 ```
 
 To modify infection parameters associated with an epidemic, users should create a `<daedalus_infection>` class
@@ -91,7 +91,7 @@ This scenario (`vaccine_investment = "none"`) is intended to represent the Covid
 
 These parameters are contained in the package data `daedalus::vaccine_scenario_data`, for a total of four scenarios of advance vaccine investment ("none", "low", "medium", and "high").
 
-Vaccine investment scenarios can be passed a string to `daedalus()` to use the default parameters for each scenario, or as a `<daedalus_vaccination>` object using `daedalus_vaccination(name, <PARAMETERS>)` to modify vaccination parameters.
+Vaccine investment scenarios can be passed a string to `daedalus2()` to use the default parameters for each scenario, or as a `<daedalus_vaccination>` object using `daedalus_vaccination(name, <PARAMETERS>)` to modify vaccination parameters.
 
 ```{r}
 # the default vaccine investment scenario
@@ -100,12 +100,12 @@ daedalus_vaccination("none")
 
 ## Running the model
 
-Run the model by passing the `country` and `infection` arguments to `daedalus()`.
+Run the model by passing the `country` and `infection` arguments to `daedalus2()`.
 The vaccine investment scenarios is automatically assumed to be "none".
 
 ```{r run_model}
 # simulate a Covid-19 wild type outbreak in Canada; using default parameters
-data <- daedalus("Canada", "sars_cov_2_pre_alpha")
+data <- daedalus2("Canada", "sars_cov_2_pre_alpha")
 ```
 
 The model runs for 300 timesteps by default; timesteps should be interpreted as days since model parameters are in terms of days.
@@ -115,7 +115,7 @@ Plot the data to view the epidemic curve.
 ```{r plot_epidemic}
 data <- get_data(data)
 ggplot(
-  data[data$compartment == "infect_symp" & data$age_group == "20-65", ]
+  data[data$compartment == "infect_symp" & data$age_group == "20-64", ]
 ) +
   geom_line(
     aes(time, value, colour = econ_sector),

--- a/vignettes/info_life_value.Rmd
+++ b/vignettes/info_life_value.Rmd
@@ -26,7 +26,7 @@ The methodology used here has been chosen so as to be generalisable for the wide
 This approach balances the ability to run _daedalus_ scenarios for a large number of countries, and the effort required to obtain and update official life-values from national governments.
 
 ::: {.alert .alert-info}
-**Note that** the VSL values used in a call to `daedalus()` for any country can always be substituted with values considered to be more appropriate (e.g., from a national health ministry).
+**Note that** the VSL values used in a call to `daedalus2()` for any country can always be substituted with values considered to be more appropriate (e.g., from a national health ministry).
 :::
 
 ## Value of a life year
@@ -83,7 +83,7 @@ x$vsl
 
 ## Value of lives lost
 
-In a `daedalus()` scenario, the total value of lives lost is the sum of the products of the country- and age-specific VSL and the number of deaths in each age-group in that country:
+In a `daedalus2()` scenario, the total value of lives lost is the sum of the products of the country- and age-specific VSL and the number of deaths in each age-group in that country:
 
 $$\Sigma_{i = 1}^{N} \text{VSL}_{c_i} \times D_i$$
 

--- a/vignettes/thresholded_response.Rmd
+++ b/vignettes/thresholded_response.Rmd
@@ -27,10 +27,12 @@ response_threshold <- 1000
 Initially run the model with no response, and then with an elimination response activated when total hospitalisations reach 1000 or after 30 days, whichever is sooner.
 
 ```{r}
-data_baseline <- daedalus(
-  "Canada",
+canada <- daedalus_country("CAN")
+canada$hospital_capacity <- response_threshold
+
+data_baseline <- daedalus2(
+  canada,
   daedalus_infection("influenza_1918", rho = 0.0), # prevent re-infection
-  response_threshold = response_threshold,
   response_strategy = "none"
 )
 
@@ -42,10 +44,9 @@ data_baseline$scenario <- "no_response"
 
 ```{r run_model}
 # run the model with a heavy elimination intervention
-data_intervention <- daedalus(
-  "Canada",
+data_intervention <- daedalus2(
+  canada,
   daedalus_infection("influenza_1918", rho = 0.0), # prevent re-infection
-  response_threshold = response_threshold,
   response_strategy = "elimination"
 )
 


### PR DESCRIPTION
This PR replaces `daedalus()` with `daedalus2()` in most places except an equivalence test. Some tests for `daedalus2()` are duplicated due to the same tests existing for `daedalus()` - these will be removed in a general test-improvement PR that follows this one. I'll remove `daedalus2()` from the namespace in a follow up PR.