### PR TITLE
Correct cost calculations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus
 Title: Model Health, Social, and Economic Costs of a Pandemic
-Version: 0.2.17
+Version: 0.2.18
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus 0.2.18
+
+Patch version to correct erroneous book-keeping of costs due to absences and closures; tests added to check that absence costs are not very low.
+
 # daedalus 0.2.17
 
 Splits off spontaneous social distancing from being linked with NPIs, and fixes a bug where specifying `response = "none"` left social distancing on by default.

--- a/tests/testthat/_snaps/costs.md
+++ b/tests/testthat/_snaps/costs.md
@@ -1,0 +1,63 @@
+# Costs: basic expectations
+
+    Code
+      costs
+    Output
+      $total_cost
+      [1] 1049499
+      
+      $economic_costs
+      $economic_costs$economic_cost_total
+      [1] 26819.05
+      
+      $economic_costs$economic_cost_closures
+      [1] 0
+      
+      $economic_costs$economic_cost_absences
+      [1] 26819.05
+      
+      $economic_costs$sector_cost_closures
+       [1] 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+      [39] 0 0 0 0 0 0 0
+      
+      $economic_costs$sector_cost_absences
+       [1]  475.74420   42.19707  846.87209  331.40184  183.03886  483.72484
+       [7]   34.77129  147.44294  180.10592  155.60012  215.63891   74.13942
+      [13]  143.84175  108.97155  174.18589  207.93008   89.55669   57.94210
+      [19]  224.33056  262.76237  166.86109  238.43748  576.09141  146.17245
+      [25] 1945.26186 3287.69264  732.78205   23.84745  142.77464  321.70453
+      [31]  126.37720  694.43846  270.33029  512.11716  534.33608 2052.03553
+      [37] 3522.08461 1273.32265  933.71782 2049.77008 1669.42218 2238.70342
+      [43]  239.97262  305.96081   44.05988
+      
+      
+      $education_costs
+      $education_costs$education_cost_total
+      [1] 1669.422
+      
+      $education_costs$education_cost_closures
+      [1] 0
+      
+      $education_costs$education_cost_absences
+      [1] 1669.422
+      
+      
+      $life_value_lost
+      $life_value_lost$life_value_lost_total
+      [1] 1021011
+      
+      $life_value_lost$life_value_lost_age
+           0-4     5-19    20-64      65+ 
+      196274.4 417796.1 269441.7 137498.3 
+      
+      
+      $life_years_lost
+      $life_years_lost$life_years_lost_total
+      [1] 22171782
+      
+      $life_years_lost$life_years_lost_age
+          0-4    5-19   20-64     65+ 
+      4262201 9072663 5851069 2985849 
+      
+      
+

--- a/tests/testthat/test-costs.R
+++ b/tests/testthat/test-costs.R
@@ -100,9 +100,6 @@ test_that("Expectations on education costs", {
     costs$economic_costs$sector_cost_absences[1]
   )
 
-  output <- daedalus("GBR", "sars_cov_1")
-  costs <- get_costs(output)
-
   # exepct that costs due to closures are non-zero, in scenarios with schools
   # closed
   x <- c("none", "school_closures", "elimination")

--- a/tests/testthat/test-costs.R
+++ b/tests/testthat/test-costs.R
@@ -10,6 +10,9 @@ test_that("Costs: basic expectations", {
   expect_no_condition({
     costs_domain <- get_costs(output, "domain")
   })
+  expect_snapshot(
+    costs
+  )
 
   checkmate::expect_list(costs, c("numeric", "list"), any.missing = FALSE)
   checkmate::expect_number(costs_total, lower = 0, finite = TRUE)
@@ -79,7 +82,27 @@ test_that("Costs: scenario expectations", {
   })
 })
 
-test_that("Expectations on schooling costs", {
+test_that("Expectations on education costs", {
+  # tests to check that education costs are correctly handled
+  output <- daedalus("GBR", "sars_cov_1")
+  costs <- get_costs(output)
+
+  # to check that matrix mult and colsums is correct in `get_costs()`
+  expect_gt(
+    round(costs$education_costs$education_cost_absences),
+    1
+  )
+
+  # expect absences in education lead to higher losses
+  # this probably works for UK due to size of education sector
+  expect_gt(
+    costs$education_costs$education_cost_absences,
+    costs$economic_costs$sector_cost_absences[1]
+  )
+
+  output <- daedalus("GBR", "sars_cov_1")
+  costs <- get_costs(output)
+
   # exepct that costs due to closures are non-zero, in scenarios with schools
   # closed
   x <- c("none", "school_closures", "elimination")


### PR DESCRIPTION
This PR reverses some (poorly organised) changes from a previous PR and corrects how costs are calculated. Some basic tests check for education costs being non-zero in known circumstances (UK education sector should always show high costs of absences or closures).