### PR TITLE
Use hfr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus
 Title: Model Health, Social, and Economic Costs of a Pandemic
-Version: 0.2.24
+Version: 0.2.25
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# daedalus 0.2.25
+
+This patch version adds the use of HFR and hospital transition rates to calculate competing rates within the C++ code, which was previously handled in `daedalus.data`.
+
+## Notes
+
+A next step will be to implement transitions out of the `H` compartment as conditional probabilities, rather than competing rates.
+
 # daedalus 0.2.24
 
 This patch version implements changes to the `<daedalus_response>` super-class that allows events to end on increasing _or_ decreasing roots on state. This is mostly (and currently only) to help end vaccination after a specific number of doses have been given out. This patch currently only applies to vaccination, with other events being updated later.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@ This patch version adds the use of HFR and hospital transition rates to calculat
 
 ## Notes
 
-A next step will be to implement transitions out of the `H` compartment as conditional probabilities, rather than competing rates.
+- A next step will be to implement transitions out of the `H` compartment as conditional probabilities, rather than competing rates.
+
+- Previous versions of `daedalus` which rely on `daedalus.data` and the old parameter sets are now superseded. Please update `daedalus.data` to version 0.0.2 if you intend to continue working with this new version of `daedalus`.
 
 # daedalus 0.2.24
 

--- a/R/class_infection.R
+++ b/R/class_infection.R
@@ -104,14 +104,17 @@ new_daedalus_infection <- function(name, parameters) {
 #' - `ifr`: A numeric vector of length `N_AGE_GROUPS` (4) for the
 #' age-specific infection fatality risk.
 #'
-#' - `gamma_H`: A numeric vector of length `N_AGE_GROUPS` (4) for the
-#' age-specific recovery rate for individuals who are hospitalised.
-#'
 #' - `eta`: A numeric vector of length `N_AGE_GROUPS` (4) for the age-specific
 #' hospitalisation rate for individuals who are infectious and symptomatic.
 #'
-#' - `omega`: A numeric vector of length `N_AGE_GROUPS` (4) for the age-specific
-#' mortality rate for individuals who are hospitalised.
+#' - `hfr`: A numeric vector of length `N_AGE_GROUPS` (4) for the age-specific
+#' probability of death conditional on hospitalisation.
+#'
+#' - `gamma_H_recovery`: A single numeric value for the recovery rate of
+#' hospitalised individuals.
+#'
+#' - `gamma_H_death`: A single numeric value for the death rate of
+#' hospitalised individuals.
 #'
 #' - `rho`: A single numeric value for the rate at which infection-derived
 #' immunity wanes, returning individuals in the 'recovered' compartment to the
@@ -151,7 +154,7 @@ daedalus_infection <- function(name, ...) {
       )
     }
 
-    allowed_numerics_names <- c("ifr", "eta", "gamma_H", "omega")
+    allowed_numerics_names <- c("ifr", "eta", "hfr")
     is_each_number <- all(vapply(
       parameters[!names(parameters) %in% allowed_numerics_names],
       checkmate::test_number,
@@ -236,7 +239,7 @@ validate_daedalus_infection <- function(x) {
   }
 
   # check class members
-  allowed_numerics_names <- c("ifr", "eta", "gamma_H", "omega")
+  allowed_numerics_names <- c("ifr", "eta", "hfr")
   expected_number <- setdiff(
     daedalus.data::infection_parameter_names,
     allowed_numerics_names
@@ -320,10 +323,11 @@ format.daedalus_infection <- function(x, ...) {
       "*" = "epsilon: {.val {x$epsilon}}",
       "*" = "rho: {.val {x$rho}}",
       "*" = "eta: {.val {x$eta}}",
-      "*" = "omega: {.val {x$omega}}",
+      "*" = "hfr: {.val {x$hfr}}",
       "*" = "gamma_Ia: {.val {x$gamma_Ia}}",
       "*" = "gamma_Is: {.val {x$gamma_Is}}",
-      "*" = "gamma_H: {.val {x$gamma_H}}"
+      "*" = "gamma_H_recovery: {.val {x$gamma_H_recovery}}",
+      "*" = "gamma_H_death: {.val {x$gamma_H_death}}"
     )
   )
   cli::cli_end(divid)
@@ -386,7 +390,7 @@ prepare_parameters.daedalus_infection <- function(x, ...) {
   validate_daedalus_infection(x)
   x <- unclass(x)
 
-  age_varying_params <- c("eta", "omega", "gamma_H")
+  age_varying_params <- c("eta", "hfr")
 
   x[age_varying_params] <- lapply(x[age_varying_params], function(p) {
     p <- c(p, rep(p[i_WORKING_AGE], N_ECON_SECTORS))

--- a/R/dust.R
+++ b/R/dust.R
@@ -6,9 +6,9 @@ daedalus_ode <- structure(
   package = "daedalus",
   path = NULL,
   parameters = data.frame(
-    name = c("beta", "sigma", "p_sigma", "epsilon", "rho", "eta", "omega", "gamma_Ia", "gamma_Is", "gamma_H", "nu", "susc", "psi", "vax_start_time", "n_age_groups", "n_econ_groups", "popsize", "cm", "cm_work", "cm_cons_work", "hospital_capacity", "openness", "response_time", "response_duration", "auto_social_distancing"),
-    type = c("real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "int", "int", "int", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type"),
-    constant = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE)),
+    name = c("beta", "sigma", "p_sigma", "epsilon", "rho", "eta", "hfr", "gamma_Ia", "gamma_Is", "gamma_H_recovery", "gamma_H_death", "nu", "susc", "psi", "vax_start_time", "n_age_groups", "n_econ_groups", "popsize", "cm", "cm_work", "cm_cons_work", "hospital_capacity", "openness", "response_time", "response_duration", "auto_social_distancing"),
+    type = c("real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "int", "int", "int", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type", "real_type"),
+    constant = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE)),
   properties = list(
     time_type = "continuous",
     has_compare = FALSE,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -15,6 +15,7 @@ GH
 GNI
 GVA
 Guzman
+HFR
 Hosptial
 IDM
 IFR
@@ -66,6 +67,7 @@ fn
 frac
 ij
 int
+iso
 lintr
 monty
 npi

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -83,9 +83,8 @@ class daedalus_ode {
   /// @brief Shared parameters and values. All const as not expected to update.
   struct shared_state {
     // NOTE: n_strata unknown at compile time
-    const real_type beta, sigma, p_sigma, epsilon, rho, gamma_Ia, gamma_Is,
-    gamma_H_recovery, gamma_H_death;
-    const TensorMat eta, hfr;
+    const real_type beta, sigma, p_sigma, epsilon, rho, gamma_Ia, gamma_Is;
+    const TensorMat eta, omega, gamma_H;
 
     const real_type nu, psi;
 
@@ -220,11 +219,11 @@ class daedalus_ode {
     TensorMat hfr = hfr_temp.broadcast(bcast);
     
     // CALCULATE AGE VARYING OMEGA AND Gamma_h
-    omega = daedalus::helpers::get_omega(
+    const TensorMat omega = daedalus::helpers::get_omega(
       hfr, gamma_H_recovery, gamma_H_death
     );
     
-    gamma_H = daedalus::helpers::get_gamma_H(
+    const TensorMat gamma_H = daedalus::helpers::get_gamma_H(
       hfr, gamma_H_recovery, gamma_H_death
     );
 
@@ -351,7 +350,7 @@ class daedalus_ode {
     return shared_state{
         beta,         sigma,      p_sigma,      epsilon,
         rho,          gamma_Ia,   gamma_Is,     eta,
-        omega,        nu,         psi,          gamma_H,
+        omega,        gamma_H,    nu,           psi,
         uptake_limit, n_strata,   n_age_groups, n_econ_groups,
         popsize,      cm,         cm_cw,
         cm_work,      susc,       openness,

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -416,6 +416,13 @@ class daedalus_ode {
         daedalus::events::switch_by_flag(daedalus::constants::d_mort_multiplier,
                                          state[shared.i_hosp_overflow_flag]);
 
+    /* CHANGE omega based on current HFR
+        omega = daedalus::helpers::process_hfr(
+            hosp_capacity, hfr, t_hosp_death, t_hosp_recovery
+        );
+    */
+
+
     // calculate total deaths and scale beta by concern, but only if an
     // NPI is active
     // TODO(pratik): change in future so public-concern is independent of NPIs

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -346,12 +346,12 @@ class daedalus_ode {
 
     // clang-format off
     return shared_state{
-        beta,         sigma,      p_sigma,      epsilon,
-        rho,          gamma_Ia,   gamma_Is,     eta,
-        omega,        gamma_H,    nu,           psi,
-        uptake_limit, n_strata,   n_age_groups, n_econ_groups,
-        popsize,      cm,         cm_cw,
-        cm_work,      susc,       openness,
+        beta,         sigma,          p_sigma,      epsilon,
+        rho,          gamma_Ia,       gamma_Is,     eta,
+        omega,        gamma_H,        nu,           psi,
+        n_strata,     n_age_groups,   n_econ_groups,
+        popsize,      cm,             cm_cw,
+        cm_work,      susc,           openness,
         i_ipr,  // state index holding incidence/prevalence ratio
         i_npi_flag,   i_vax_flag, i_sd_flag,    i_hosp_overflow_flag,
         npi,          vaccination,

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -204,9 +204,9 @@ class daedalus_ode {
     const real_type rho = dust2::r::read_real(pars, "rho", 0.0);
     const real_type gamma_Ia = dust2::r::read_real(pars, "gamma_Ia", 0.0);
     const real_type gamma_Is = dust2::r::read_real(pars, "gamma_Is", 0.0);
-    const real_type gamma_H_recovery = 
+    const real_type gamma_H_recovery =
       dust2::r::read_real(pars, "gamma_H_recovery", 0.0);
-    const real_type gamma_H_death = 
+    const real_type gamma_H_death =
       dust2::r::read_real(pars, "gamma_H_death", 0.0);
 
     // EPI PARAMETERS: AGE VARYING
@@ -217,15 +217,13 @@ class daedalus_ode {
     dust2::r::read_real_vector(pars, n_strata, hfr_temp.data(), "hfr", true);
     TensorMat eta = eta_temp.broadcast(bcast);
     TensorMat hfr = hfr_temp.broadcast(bcast);
-    
+
     // CALCULATE AGE VARYING OMEGA AND Gamma_h
     const TensorMat omega = daedalus::helpers::get_omega(
-      hfr, gamma_H_recovery, gamma_H_death
-    );
-    
+      hfr, gamma_H_recovery, gamma_H_death);
+
     const TensorMat gamma_H = daedalus::helpers::get_gamma_H(
-      hfr, gamma_H_recovery, gamma_H_death
-    );
+      hfr, gamma_H_recovery, gamma_H_death);
 
     // CONTACT PARAMETERS (MATRICES)
     // contact matrix
@@ -420,7 +418,7 @@ class daedalus_ode {
     // calculate total hospitalisations to check if hosp capacity is exceeded;
     // scale mortality rate by 1.6 if so
     Eigen::Tensor<double, 0> total_hosp = t_x.chip(iH, i_COMPS).sum();
-    
+
     const double omega_modifier =
       daedalus::events::switch_by_flag(daedalus::constants::d_mort_multiplier,
                                        state[shared.i_hosp_overflow_flag]);

--- a/inst/include/daedalus_helpers.h
+++ b/inst/include/daedalus_helpers.h
@@ -64,7 +64,7 @@ inline daedalus::types::TensorMat<double> get_omega(
     const daedalus::types::TensorMat<double> &hfr,
     const double &gamma_H_recovery,
     const double &gamma_H_death) {
-  
+
   const double thD = 1.0 / gamma_H_death;
   const double thR = 1.0 / gamma_H_recovery;
 

--- a/inst/include/daedalus_helpers.h
+++ b/inst/include/daedalus_helpers.h
@@ -60,12 +60,14 @@ inline std::vector<size_t> get_state_idx(
 /// @brief Process severity parameters to define a death death, based on the
 /// HFR and lengths of hospital stay of the pathogen being simulated, as 
 /// specified in `daedalus.data`.
-inline double get_omega(const double hfr, 
-                        const double gamma_H_recovery,
-                        const double gamma_H_death) {
+inline daedalus::types::TensorMat<double> get_omega(
+    const daedalus::types::TensorMat<double> &hfr, 
+    const double &gamma_H_recovery,
+    const double &gamma_H_death) {
   
-  const double t_hosp = hfr * gamma_H_death + (1 - hfr) * gamma_H_recovery;
-  const double omega = hfr / t_hosp;
+  const daedalus::types::TensorMat<double> t_hosp = 
+    hfr * gamma_H_death + (1.0 - hfr) * gamma_H_recovery;
+  const daedalus::types::TensorMat<double> omega = hfr / t_hosp;
   
   return omega;
 }
@@ -74,12 +76,14 @@ inline double get_omega(const double hfr,
 /// @brief Process severity parameters to define a death death, based on the
 /// HFR and lengths of hospital stay of the pathogen being simulated, as 
 /// specified in `daedalus.data`.
-inline double get_gamma_H(const double hfr, 
-                          const double gamma_H_recovery,
-                          const double gamma_H_death) {
+inline daedalus::types::TensorMat<double> get_gamma_H(
+    const daedalus::types::TensorMat<double> &hfr, 
+    const double &gamma_H_recovery,
+    const double &gamma_H_death) {
   
-  const double t_hosp = hfr * gamma_H_death + (1 - hfr) * gamma_H_recovery;
-  const double gamma_H = (1 - hfr) / t_hosp;
+  const daedalus::types::TensorMat<double> t_hosp = 
+    hfr * gamma_H_death + (1.0 - hfr) * gamma_H_recovery;
+  const daedalus::types::TensorMat<double> gamma_H = (1.0 - hfr) / t_hosp;
   
   return gamma_H;
 }

--- a/inst/include/daedalus_helpers.h
+++ b/inst/include/daedalus_helpers.h
@@ -64,9 +64,12 @@ inline daedalus::types::TensorMat<double> get_omega(
     const daedalus::types::TensorMat<double> &hfr,
     const double &gamma_H_recovery,
     const double &gamma_H_death) {
+  
+  const double thD = 1.0 / gamma_H_death;
+  const double thR = 1.0 / gamma_H_recovery;
 
   const daedalus::types::TensorMat<double> t_hosp =
-    hfr * gamma_H_death + (1.0 - hfr) * gamma_H_recovery;
+    hfr * thD + (1.0 - hfr) * thR;
   const daedalus::types::TensorMat<double> omega = hfr / t_hosp;
 
   return omega;
@@ -81,8 +84,11 @@ inline daedalus::types::TensorMat<double> get_gamma_H(
     const double &gamma_H_recovery,
     const double &gamma_H_death) {
 
+  const double thD = 1.0 / gamma_H_death;
+  const double thR = 1.0 / gamma_H_recovery;
+
   const daedalus::types::TensorMat<double> t_hosp =
-    hfr * gamma_H_death + (1.0 - hfr) * gamma_H_recovery;
+    hfr * thD + (1.0 - hfr) * thR;
   const daedalus::types::TensorMat<double> gamma_H = (1.0 - hfr) / t_hosp;
 
   return gamma_H;

--- a/inst/include/daedalus_helpers.h
+++ b/inst/include/daedalus_helpers.h
@@ -55,6 +55,35 @@ inline std::vector<size_t> get_state_idx(
   return i_to_zero;
 }
 
+
+
+/// @brief Process severity parameters to define a death death, based on the
+/// HFR and lengths of hospital stay of the pathogen being simulated, as 
+/// specified in `daedalus.data`.
+inline double get_omega(const double hfr, 
+                        const double gamma_H_recovery,
+                        const double gamma_H_death) {
+  
+  const double t_hosp = hfr * gamma_H_death + (1 - hfr) * gamma_H_recovery;
+  const double omega = hfr / t_hosp;
+  
+  return omega;
+}
+
+
+/// @brief Process severity parameters to define a death death, based on the
+/// HFR and lengths of hospital stay of the pathogen being simulated, as 
+/// specified in `daedalus.data`.
+inline double get_gamma_H(const double hfr, 
+                          const double gamma_H_recovery,
+                          const double gamma_H_death) {
+  
+  const double t_hosp = hfr * gamma_H_death + (1 - hfr) * gamma_H_recovery;
+  const double gamma_H = (1 - hfr) / t_hosp;
+  
+  return gamma_H;
+}
+
 /// @brief Get a scaled vaccination rate to ensure that initial vaccination rate
 /// is maintained as the number of eligible individuals decreases (doses remain
 /// constant).

--- a/inst/include/daedalus_helpers.h
+++ b/inst/include/daedalus_helpers.h
@@ -58,33 +58,33 @@ inline std::vector<size_t> get_state_idx(
 
 
 /// @brief Process severity parameters to define a death death, based on the
-/// HFR and lengths of hospital stay of the pathogen being simulated, as 
+/// HFR and lengths of hospital stay of the pathogen being simulated, as
 /// specified in `daedalus.data`.
 inline daedalus::types::TensorMat<double> get_omega(
-    const daedalus::types::TensorMat<double> &hfr, 
+    const daedalus::types::TensorMat<double> &hfr,
     const double &gamma_H_recovery,
     const double &gamma_H_death) {
-  
-  const daedalus::types::TensorMat<double> t_hosp = 
+
+  const daedalus::types::TensorMat<double> t_hosp =
     hfr * gamma_H_death + (1.0 - hfr) * gamma_H_recovery;
   const daedalus::types::TensorMat<double> omega = hfr / t_hosp;
-  
+
   return omega;
 }
 
 
 /// @brief Process severity parameters to define a death death, based on the
-/// HFR and lengths of hospital stay of the pathogen being simulated, as 
+/// HFR and lengths of hospital stay of the pathogen being simulated, as
 /// specified in `daedalus.data`.
 inline daedalus::types::TensorMat<double> get_gamma_H(
-    const daedalus::types::TensorMat<double> &hfr, 
+    const daedalus::types::TensorMat<double> &hfr,
     const double &gamma_H_recovery,
     const double &gamma_H_death) {
-  
-  const daedalus::types::TensorMat<double> t_hosp = 
+
+  const daedalus::types::TensorMat<double> t_hosp =
     hfr * gamma_H_death + (1.0 - hfr) * gamma_H_recovery;
   const daedalus::types::TensorMat<double> gamma_H = (1.0 - hfr) / t_hosp;
-  
+
   return gamma_H;
 }
 

--- a/man/class_infection.Rd
+++ b/man/class_infection.Rd
@@ -81,12 +81,14 @@ individuals who are not hospitalised.
 infection.
 \item \code{ifr}: A numeric vector of length \code{N_AGE_GROUPS} (4) for the
 age-specific infection fatality risk.
-\item \code{gamma_H}: A numeric vector of length \code{N_AGE_GROUPS} (4) for the
-age-specific recovery rate for individuals who are hospitalised.
 \item \code{eta}: A numeric vector of length \code{N_AGE_GROUPS} (4) for the age-specific
 hospitalisation rate for individuals who are infectious and symptomatic.
-\item \code{omega}: A numeric vector of length \code{N_AGE_GROUPS} (4) for the age-specific
-mortality rate for individuals who are hospitalised.
+\item \code{hfr}: A numeric vector of length \code{N_AGE_GROUPS} (4) for the age-specific
+probability of death conditional on hospitalisation.
+\item \code{gamma_H_recovery}: A single numeric value for the recovery rate of
+hospitalised individuals.
+\item \code{gamma_H_death}: A single numeric value for the death rate of
+hospitalised individuals.
 \item \code{rho}: A single numeric value for the rate at which infection-derived
 immunity wanes, returning individuals in the 'recovered' compartment to the
 'susceptible' compartment.

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -56,10 +56,11 @@ using TensorAry = daedalus::types::TensorAry<double>;
 // [[dust2::parameter(epsilon, constant = TRUE)]]
 // [[dust2::parameter(rho, constant = TRUE)]]
 // [[dust2::parameter(eta, constant = TRUE)]]
-// [[dust2::parameter(omega, constant = TRUE)]]
+// [[dust2::parameter(hfr, constant = TRUE)]]
 // [[dust2::parameter(gamma_Ia, constant = TRUE)]]
 // [[dust2::parameter(gamma_Is, constant = TRUE)]]
-// [[dust2::parameter(gamma_H, constant = TRUE)]]
+// [[dust2::parameter(gamma_H_recovery, constant = TRUE)]]
+// [[dust2::parameter(gamma_H_death, constant = TRUE)]]
 // [[dust2::parameter(nu, constant = TRUE)]]
 // [[dust2::parameter(susc, constant = TRUE)]]
 // [[dust2::parameter(psi, constant = TRUE)]]
@@ -84,8 +85,9 @@ class daedalus_ode {
   /// @brief Shared parameters and values. All const as not expected to update.
   struct shared_state {
     // NOTE: n_strata unknown at compile time
-    const real_type beta, sigma, p_sigma, epsilon, rho, gamma_Ia, gamma_Is;
-    const TensorMat eta, omega, gamma_H;
+    const real_type beta, sigma, p_sigma, epsilon, rho, gamma_Ia, gamma_Is,
+    gamma_H_recovery, gamma_H_death;
+    const TensorMat eta, hfr;
 
     const real_type nu, psi;
 
@@ -205,20 +207,28 @@ class daedalus_ode {
     const real_type rho = dust2::r::read_real(pars, "rho", 0.0);
     const real_type gamma_Ia = dust2::r::read_real(pars, "gamma_Ia", 0.0);
     const real_type gamma_Is = dust2::r::read_real(pars, "gamma_Is", 0.0);
+    const real_type gamma_H_recovery = 
+      dust2::r::read_real(pars, "gamma_H_recovery", 0.0);
+    const real_type gamma_H_death = 
+      dust2::r::read_real(pars, "gamma_H_death", 0.0);
 
     // EPI PARAMETERS: AGE VARYING
     TensorMat eta_temp(n_strata, 1);
-    TensorMat omega_temp(n_strata, 1);
-    TensorMat gamma_H_temp(n_strata, 1);
+    TensorMat hfr_temp(n_strata, 1);
 
     dust2::r::read_real_vector(pars, n_strata, eta_temp.data(), "eta", true);
-    dust2::r::read_real_vector(pars, n_strata, omega_temp.data(), "omega",
-                               true);
-    dust2::r::read_real_vector(pars, n_strata, gamma_H_temp.data(), "gamma_H",
-                               true);
+    dust2::r::read_real_vector(pars, n_strata, hfr_temp.data(), "hfr", true);
     TensorMat eta = eta_temp.broadcast(bcast);
-    TensorMat omega = omega_temp.broadcast(bcast);
-    TensorMat gamma_H = gamma_H_temp.broadcast(bcast);
+    TensorMat hfr = hfr_temp.broadcast(bcast);
+    
+    // CALCULATE AGE VARYING OMEGA AND Gamma_h
+    omega = daedalus::helpers::get_omega(
+      hfr, gamma_H_recovery, gamma_H_death
+    );
+    
+    gamma_H = daedalus::helpers::get_gamma_H(
+      hfr, gamma_H_recovery, gamma_H_death
+    );
 
     // CONTACT PARAMETERS (MATRICES)
     // contact matrix
@@ -343,9 +353,9 @@ class daedalus_ode {
     return shared_state{
         beta,         sigma,      p_sigma,      epsilon,
         rho,          gamma_Ia,   gamma_Is,     eta,
-        omega,        gamma_H,    nu,           psi,
-        n_strata,   n_age_groups, n_econ_groups,
-        popsize,      cm,           cm_cw,
+        omega,        nu,         psi,          gamma_H,
+        uptake_limit, n_strata,   n_age_groups, n_econ_groups,
+        popsize,      cm,         cm_cw,
         cm_work,      susc,       openness,
         i_ipr,  // state index holding incidence/prevalence ratio
         i_npi_flag,   i_vax_flag, i_sd_flag,    i_hosp_overflow_flag,
@@ -413,10 +423,10 @@ class daedalus_ode {
     // calculate total hospitalisations to check if hosp capacity is exceeded;
     // scale mortality rate by 1.6 if so
     Eigen::Tensor<double, 0> total_hosp = t_x.chip(iH, i_COMPS).sum();
-
+    
     const double omega_modifier =
-        daedalus::events::switch_by_flag(daedalus::constants::d_mort_multiplier,
-                                         state[shared.i_hosp_overflow_flag]);
+      daedalus::events::switch_by_flag(daedalus::constants::d_mort_multiplier,
+                                       state[shared.i_hosp_overflow_flag]);
 
     // calculate total deaths and scale beta by concern, but only if an
     // NPI is active

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -206,9 +206,9 @@ class daedalus_ode {
     const real_type rho = dust2::r::read_real(pars, "rho", 0.0);
     const real_type gamma_Ia = dust2::r::read_real(pars, "gamma_Ia", 0.0);
     const real_type gamma_Is = dust2::r::read_real(pars, "gamma_Is", 0.0);
-    const real_type gamma_H_recovery = 
+    const real_type gamma_H_recovery =
       dust2::r::read_real(pars, "gamma_H_recovery", 0.0);
-    const real_type gamma_H_death = 
+    const real_type gamma_H_death =
       dust2::r::read_real(pars, "gamma_H_death", 0.0);
 
     // EPI PARAMETERS: AGE VARYING
@@ -219,15 +219,13 @@ class daedalus_ode {
     dust2::r::read_real_vector(pars, n_strata, hfr_temp.data(), "hfr", true);
     TensorMat eta = eta_temp.broadcast(bcast);
     TensorMat hfr = hfr_temp.broadcast(bcast);
-    
+
     // CALCULATE AGE VARYING OMEGA AND Gamma_h
     const TensorMat omega = daedalus::helpers::get_omega(
-      hfr, gamma_H_recovery, gamma_H_death
-    );
-    
+      hfr, gamma_H_recovery, gamma_H_death);
+
     const TensorMat gamma_H = daedalus::helpers::get_gamma_H(
-      hfr, gamma_H_recovery, gamma_H_death
-    );
+      hfr, gamma_H_recovery, gamma_H_death);
 
     // CONTACT PARAMETERS (MATRICES)
     // contact matrix
@@ -350,12 +348,12 @@ class daedalus_ode {
 
     // clang-format off
     return shared_state{
-        beta,         sigma,      p_sigma,      epsilon,
-        rho,          gamma_Ia,   gamma_Is,     eta,
-        omega,        gamma_H,    nu,           psi,
-        uptake_limit, n_strata,   n_age_groups, n_econ_groups,
-        popsize,      cm,         cm_cw,
-        cm_work,      susc,       openness,
+        beta,         sigma,          p_sigma,      epsilon,
+        rho,          gamma_Ia,       gamma_Is,     eta,
+        omega,        gamma_H,        nu,           psi,
+        n_strata,     n_age_groups,   n_econ_groups,
+        popsize,      cm,             cm_cw,
+        cm_work,      susc,           openness,
         i_ipr,  // state index holding incidence/prevalence ratio
         i_npi_flag,   i_vax_flag, i_sd_flag,    i_hosp_overflow_flag,
         npi,          vaccination,
@@ -422,7 +420,7 @@ class daedalus_ode {
     // calculate total hospitalisations to check if hosp capacity is exceeded;
     // scale mortality rate by 1.6 if so
     Eigen::Tensor<double, 0> total_hosp = t_x.chip(iH, i_COMPS).sum();
-    
+
     const double omega_modifier =
       daedalus::events::switch_by_flag(daedalus::constants::d_mort_multiplier,
                                        state[shared.i_hosp_overflow_flag]);

--- a/src/daedalus.cpp
+++ b/src/daedalus.cpp
@@ -85,9 +85,8 @@ class daedalus_ode {
   /// @brief Shared parameters and values. All const as not expected to update.
   struct shared_state {
     // NOTE: n_strata unknown at compile time
-    const real_type beta, sigma, p_sigma, epsilon, rho, gamma_Ia, gamma_Is,
-    gamma_H_recovery, gamma_H_death;
-    const TensorMat eta, hfr;
+    const real_type beta, sigma, p_sigma, epsilon, rho, gamma_Ia, gamma_Is;
+    const TensorMat eta, omega, gamma_H;
 
     const real_type nu, psi;
 
@@ -222,11 +221,11 @@ class daedalus_ode {
     TensorMat hfr = hfr_temp.broadcast(bcast);
     
     // CALCULATE AGE VARYING OMEGA AND Gamma_h
-    omega = daedalus::helpers::get_omega(
+    const TensorMat omega = daedalus::helpers::get_omega(
       hfr, gamma_H_recovery, gamma_H_death
     );
     
-    gamma_H = daedalus::helpers::get_gamma_H(
+    const TensorMat gamma_H = daedalus::helpers::get_gamma_H(
       hfr, gamma_H_recovery, gamma_H_death
     );
 
@@ -353,7 +352,7 @@ class daedalus_ode {
     return shared_state{
         beta,         sigma,      p_sigma,      epsilon,
         rho,          gamma_Ia,   gamma_Is,     eta,
-        omega,        nu,         psi,          gamma_H,
+        omega,        gamma_H,    nu,           psi,
         uptake_limit, n_strata,   n_age_groups, n_econ_groups,
         popsize,      cm,         cm_cw,
         cm_work,      susc,       openness,

--- a/tests/testthat/_snaps/class_daedalus_infection.md
+++ b/tests/testthat/_snaps/class_daedalus_infection.md
@@ -11,8 +11,9 @@
       * epsilon: 0.58
       * rho: 0.003
       * eta: 0.018, 0.082, 0.018, and 0.246
-      * omega: 0.012, 0.012, 0.012, and 0.012
+      * hfr: 0.255, 0.255, 0.255, and 0.255
       * gamma_Ia: 0.476
       * gamma_Is: 0.25
-      * gamma_H: 0.034, 0.034, 0.034, and 0.034
+      * gamma_H_recovery: 0.044
+      * gamma_H_death: 0.05
 

--- a/tests/testthat/_snaps/costs.new.md
+++ b/tests/testthat/_snaps/costs.new.md
@@ -1,0 +1,63 @@
+# Costs: basic expectations
+
+    Code
+      costs
+    Output
+      $total_cost
+      [1] 1470702
+      
+      $economic_costs
+      $economic_costs$economic_cost_total
+      [1] 33925.7
+      
+      $economic_costs$economic_cost_closures
+      [1] 0
+      
+      $economic_costs$economic_cost_absences
+      [1] 33925.7
+      
+      $economic_costs$sector_cost_closures
+       [1] 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+      [39] 0 0 0 0 0 0 0
+      
+      $economic_costs$sector_cost_absences
+       [1]  613.83617   53.83231 1087.57046  423.12849  235.49126  613.24361
+       [7]   43.89818  189.36617  230.93128  197.90782  272.98786   94.51473
+      [13]  184.56943  138.53147  220.43940  266.18885  114.65652   73.24731
+      [19]  282.92645  335.00189  214.43914  301.85936  726.46082  186.44255
+      [25] 2507.97384 4090.46302  919.51130   30.60547  182.48373  403.91635
+      [31]  157.07859  870.83580  345.12725  648.34640  676.24734 2608.54699
+      [37] 4470.44733 1605.35447 1166.26519 2602.52905 2084.67549 2792.82777
+      [43]  296.87032  392.07923   56.71811
+      
+      
+      $education_costs
+      $education_costs$education_cost_total
+      [1] 2084.675
+      
+      $education_costs$education_cost_closures
+      [1] 0
+      
+      $education_costs$education_cost_absences
+      [1] 2084.675
+      
+      
+      $life_value_lost
+      $life_value_lost$life_value_lost_total
+      [1] 1434691
+      
+      $life_value_lost$life_value_lost_age
+           0-4     5-19    20-64      65+ 
+      256057.7 576896.4 395656.4 206080.9 
+      
+      
+      $life_years_lost
+      $life_years_lost$life_years_lost_total
+      [1] 31155077
+      
+      $life_years_lost$life_years_lost_age
+           0-4     5-19    20-64      65+ 
+       5560427 12527609  8591886  4475155 
+      
+      
+

--- a/tests/testthat/test-class_daedalus_infection.R
+++ b/tests/testthat/test-class_daedalus_infection.R
@@ -59,13 +59,13 @@ test_that("class <daedalus_infection>: getting parameters", {
   infection_x <- daedalus_infection("influenza_1918")
   expect_no_condition({
     x <- get_data(infection_x, "r0") # nolint
-    y <- get_data(infection_x, "omega") # nolint
+    y <- get_data(infection_x, "hfr") # nolint
   })
   checkmate::expect_number(x, lower = 0, finite = TRUE)
   checkmate::expect_numeric(y, len = N_AGE_GROUPS, lower = 0, finite = TRUE)
 
   expect_error(
-    get_data(infection_x, c("r0", "omega")),
+    get_data(infection_x, c("r0", "hfr")),
     regexp = "must be a string"
   )
 })
@@ -105,7 +105,7 @@ test_that("class <daedalus_infection>: validator", {
 
   x <- daedalus_infection("influenza_1918")
   x <- unclass(x)
-  x$omega <- rep(1, N_AGE_GROUPS - 1)
+  x$hfr <- rep(1, N_AGE_GROUPS - 1)
   class(x) <- "daedalus_infection"
   expect_error(validate_daedalus_infection(x))
 })
@@ -129,7 +129,7 @@ test_that("class <daedalus_infection>: errors", {
   )
 
   expect_error(
-    daedalus_infection("sars_cov_1", omega = rep(1, N_AGE_GROUPS - 1)),
+    daedalus_infection("sars_cov_1", hfr = rep(1, N_AGE_GROUPS - 1)),
     regexp = "Expected.*following parameters.*to be numeric.*length 4"
   )
 

--- a/vignettes/daedalus.Rmd
+++ b/vignettes/daedalus.Rmd
@@ -80,7 +80,7 @@ Users can also override epidemic-specific infection parameter values when creati
 daedalus_infection("sars_cov_1", r0 = 2.3)
 
 # Influenza 1918 but with mortality rising with age
-daedalus_infection("influenza_1918", omega = c(0.01, 0.02, 0.03, 0.1))
+daedalus_infection("influenza_1918", hfr = c(0.01, 0.02, 0.03, 0.1))
 ```
 
 ## Representing vaccine investment for pandemic preparedness


### PR DESCRIPTION
This draft PR is a first step to addressing #102. We:

- Implement the use of HFR within the cpp code
- Calculate competing rates gamma_H and omega, using HFR and rates from H to recovery and death

As a next step, we will need to modify the ODEs to use HFR as a conditional probability, instead of calculating competing rates. 

Note: differences in model outputs of costs and deaths/recoveries have crept up as a result of the above changes. Whilst small, they are a bit disconcerting as essentially the calculation in cpp is exactly the same as what we previously had in `daedalus.data`.