### PR TITLE
Allow population to begin partially immune

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus
 Title: Model Health, Social, and Economic Costs of a Pandemic
-Version: 0.2.28
+Version: 0.2.28.9000
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# daedalus (development version)
+
+This patch version implements a request from UKHSA to allow modelling pre-existing immunity by placing some proportion of the model population in the vaccinated stratum during model initialisation, by specifying `p_immune` in `initial_state_manual` in `daedalus()` and `daedalus_multi_infection()`. See function documentation details for more.
+
 # daedalus 0.2.28
 
 This patch makes a small fix to the internal function `prepare_data()` to make it robust to user-created country demography vectors when the vector names are stripped. Timesteps are now taken from the parent function `daedalus()` and `daedalus_multi_infection()`.

--- a/R/class_vaccination.R
+++ b/R/class_vaccination.R
@@ -322,6 +322,13 @@ prepare_parameters.daedalus_vaccination <- function(x, ...) {
 
 #' Dummy vaccination
 #'
+#' The efficacy of a dummy vaccination object is set to 50% as a stop-gap
+#' implementation of pre-existing population immunity. In scenarios where a
+#' 'true' vaccination scenario is to be passed, it doesn't matter. In scenarios
+#' where no vaccination is intended, it allows any individuals with pre-existing
+#' immunity to be only partially susceptible, while still preventing any
+#' model-time vaccinations as the `rate` is set to 0.
+#'
 #' @return A `daedalus_vaccination` object intended to have no effect;
 #' vaccination rate and efficacy are set to zero.
 #'
@@ -330,7 +337,7 @@ dummy_vaccination <- function() {
   # a dummy vaccination with rates and start set to zero
   params <- list(
     rate = 0,
-    efficacy = 0,
+    efficacy = 50, # set > 0 for any pre-existing immunity in initial_state
     start_time = 0,
     uptake_limit = 0,
     waning_period = 1

--- a/R/daedalus.R
+++ b/R/daedalus.R
@@ -167,9 +167,15 @@ daedalus_internal <- function(
 #' transmission as a function of daily deaths. See **Details** for more.
 #'
 #' @param initial_state_manual An optional **named** list with the names
-#' `p_infectious` and `p_asymptomatic` for the proportion of infectious and
-#' symptomatic individuals in each age group and economic sector.
+#' `p_infectious`, `p_asymptomatic`, and `p_immune`.
+#' `p_infectious` and `p_asymptomatic` give the proportion of
+#' infectious and symptomatic individuals in each age group and economic sector.
 #' Defaults to `1e-6` and `0.0` respectively.
+#' `p_immune` may be a single number in the range `0.0 <= p_immune <= 1.0` or a
+#' 4-element vector in that range (the number of age groups in the model), for
+#' the proportion of individuals in the population or in each age group that
+#' have some pre-existing immunity to infection (reduced susceptibility). See
+#' **Details** for more.
 #'
 #' @param time_end An integer-like value for the number of timesteps
 #' at which to return data. This is treated as the number of days with data
@@ -192,6 +198,16 @@ daedalus_internal <- function(
 #' - `p_asymptomatic`: A single numeric value in the range \eqn{[0.0, 1.0]} for
 #' the proportion of initially infectious individuals who are considered to be
 #' asymptomatic. Defaults to 0.0.
+#'
+#' - `p_immune`: Either a single number or a vector of 4 elements (the number
+#' of age groups) in the range \eqn{[0.0, 1.0]} for the proportion of the
+#' population (or each age group) that is considered to have pre-existing
+#' immunity. This is a stop-gap implementation that assumes one of two cases:
+#' (1) if no vaccination is intended in the model and `vaccine_investment` is
+#' `NULL`, the susceptibility of individuals pre-existing immunity is 50%; or
+#' (2) if a vaccination strategy is specified, the pre-existing immunity is
+#' assumed to be from a prior rollout, and the susceptibility is determined by
+#' the chosen vaccination strategy (as `1 - efficacy`).
 #'
 #' ## Details: Spontaneous social distancing
 #'

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -37,6 +37,8 @@ SARS
 SEIR
 Sumali
 TSL
+Timesteps
+UKHSA
 VLY
 VPE
 VSD
@@ -67,7 +69,6 @@ fn
 frac
 ij
 int
-iso
 lintr
 monty
 npi
@@ -79,6 +80,7 @@ parameterise
 pathogendata
 recovered’
 rightarrow
+rollout
 rootfinding
 socioeconomic
 specifc

--- a/man/daedalus.Rd
+++ b/man/daedalus.Rd
@@ -66,9 +66,15 @@ spontaneous social distancing in the model, which reduces infection
 transmission as a function of daily deaths. See \strong{Details} for more.}
 
 \item{initial_state_manual}{An optional \strong{named} list with the names
-\code{p_infectious} and \code{p_asymptomatic} for the proportion of infectious and
-symptomatic individuals in each age group and economic sector.
-Defaults to \code{1e-6} and \code{0.0} respectively.}
+\code{p_infectious}, \code{p_asymptomatic}, and \code{p_immune}.
+\code{p_infectious} and \code{p_asymptomatic} give the proportion of
+infectious and symptomatic individuals in each age group and economic sector.
+Defaults to \code{1e-6} and \code{0.0} respectively.
+\code{p_immune} may be a single number in the range \verb{0.0 <= p_immune <= 1.0} or a
+4-element vector in that range (the number of age groups in the model), for
+the proportion of individuals in the population or in each age group that
+have some pre-existing immunity to infection (reduced susceptibility). See
+\strong{Details} for more.}
 
 \item{time_end}{An integer-like value for the number of timesteps
 at which to return data. This is treated as the number of days with data
@@ -98,6 +104,15 @@ million as infectious.
 \item \code{p_asymptomatic}: A single numeric value in the range \eqn{[0.0, 1.0]} for
 the proportion of initially infectious individuals who are considered to be
 asymptomatic. Defaults to 0.0.
+\item \code{p_immune}: Either a single number or a vector of 4 elements (the number
+of age groups) in the range \eqn{[0.0, 1.0]} for the proportion of the
+population (or each age group) that is considered to have pre-existing
+immunity. This is a stop-gap implementation that assumes one of two cases:
+(1) if no vaccination is intended in the model and \code{vaccine_investment} is
+\code{NULL}, the susceptibility of individuals pre-existing immunity is 50\%; or
+(2) if a vaccination strategy is specified, the pre-existing immunity is
+assumed to be from a prior rollout, and the susceptibility is determined by
+the chosen vaccination strategy (as \code{1 - efficacy}).
 }
 }
 

--- a/man/daedalus_multi_infection.Rd
+++ b/man/daedalus_multi_infection.Rd
@@ -60,9 +60,15 @@ spontaneous social distancing in the model, which reduces infection
 transmission as a function of daily deaths. See \strong{Details} for more.}
 
 \item{initial_state_manual}{An optional \strong{named} list with the names
-\code{p_infectious} and \code{p_asymptomatic} for the proportion of infectious and
-symptomatic individuals in each age group and economic sector.
-Defaults to \code{1e-6} and \code{0.0} respectively.}
+\code{p_infectious}, \code{p_asymptomatic}, and \code{p_immune}.
+\code{p_infectious} and \code{p_asymptomatic} give the proportion of
+infectious and symptomatic individuals in each age group and economic sector.
+Defaults to \code{1e-6} and \code{0.0} respectively.
+\code{p_immune} may be a single number in the range \verb{0.0 <= p_immune <= 1.0} or a
+4-element vector in that range (the number of age groups in the model), for
+the proportion of individuals in the population or in each age group that
+have some pre-existing immunity to infection (reduced susceptibility). See
+\strong{Details} for more.}
 
 \item{time_end}{An integer-like value for the number of timesteps
 at which to return data. This is treated as the number of days with data

--- a/man/dummy_vaccination.Rd
+++ b/man/dummy_vaccination.Rd
@@ -11,6 +11,11 @@ A \code{daedalus_vaccination} object intended to have no effect;
 vaccination rate and efficacy are set to zero.
 }
 \description{
-Dummy vaccination
+The efficacy of a dummy vaccination object is set to 50\% as a stop-gap
+implementation of pre-existing population immunity. In scenarios where a
+'true' vaccination scenario is to be passed, it doesn't matter. In scenarios
+where no vaccination is intended, it allows any individuals with pre-existing
+immunity to be only partially susceptible, while still preventing any
+model-time vaccinations as the \code{rate} is set to 0.
 }
 \keyword{internal}

--- a/man/make_initial_state.Rd
+++ b/man/make_initial_state.Rd
@@ -20,9 +20,15 @@ To override package defaults for country characteristics, pass a
 \verb{<daedalus_country>} object instead. See \code{\link[=daedalus_country]{daedalus_country()}} for more.}
 
 \item{initial_state_manual}{An optional \strong{named} list with the names
-\code{p_infectious} and \code{p_asymptomatic} for the proportion of infectious and
-symptomatic individuals in each age group and economic sector.
-Defaults to \code{1e-6} and \code{0.0} respectively.}
+\code{p_infectious}, \code{p_asymptomatic}, and \code{p_immune}.
+\code{p_infectious} and \code{p_asymptomatic} give the proportion of
+infectious and symptomatic individuals in each age group and economic sector.
+Defaults to \code{1e-6} and \code{0.0} respectively.
+\code{p_immune} may be a single number in the range \verb{0.0 <= p_immune <= 1.0} or a
+4-element vector in that range (the number of age groups in the model), for
+the proportion of individuals in the population or in each age group that
+have some pre-existing immunity to infection (reduced susceptibility). See
+\strong{Details} for more.}
 }
 \value{
 An array with as many dimensions as \code{N_VACCINE_DATA_GROUPS}

--- a/tests/testthat/test-model_helpers.R
+++ b/tests/testthat/test-model_helpers.R
@@ -1,6 +1,89 @@
 # Test that errors from initial state preparation are bubbled up
-country_canada <- daedalus_country("Canada")
+test_that("Initial vaccinated proportion is correct", {
+  p_immune <- 0.5
+  state <- make_initial_state(daedalus_country("GB"), list(p_immune = p_immune))
+
+  n_comps <- (N_AGE_GROUPS + N_ECON_SECTORS) * N_MODEL_COMPARTMENTS
+  i_unvaxxed <- 1:n_comps
+  i_vaxxed <- (n_comps + 1):(n_comps * 2L)
+
+  expect_identical(
+    state[i_unvaxxed],
+    state[i_vaxxed]
+  )
+
+  p_immune <- 1 / 4
+  state <- make_initial_state(daedalus_country("GB"), list(p_immune = p_immune))
+  expect_identical(
+    state[i_vaxxed],
+    state[i_unvaxxed] / 3,
+    tolerance = 1e-6
+  )
+
+  # initialising with some vaccinated works
+  expect_no_condition(
+    daedalus(
+      "GB",
+      "sars_cov_1",
+      initial_state_manual = list(p_immune = p_immune),
+      time_end = 100
+    )
+  )
+  expect_no_condition(
+    daedalus(
+      "GB",
+      "sars_cov_1",
+      initial_state_manual = list(p_immune = p_immune),
+      vaccine_investment = "high",
+      time_end = 300
+    )
+  )
+
+  # phenomenological correctness --- final size is smaller
+  out_1 <- daedalus(
+    "GB",
+    "sars_cov_1",
+    initial_state_manual = list(p_immune = p_immune),
+    time_end = 100
+  )
+  out_2 <- daedalus(
+    "GB",
+    "sars_cov_1",
+    time_end = 100
+  )
+  fs_1 <- get_epidemic_summary(out_1, "infections")$value
+  fs_2 <- get_epidemic_summary(out_2, "infections")$value
+  expect_lt(
+    fs_1,
+    fs_2
+  )
+
+  # initialising with age-specific p_immune
+  p_immune <- c(0, 0, 0, 0.4)
+  expect_no_condition(
+    daedalus(
+      "GB",
+      "sars_cov_1",
+      initial_state_manual = list(p_immune = p_immune),
+      time_end = 100
+    )
+  )
+
+  out_1 <- daedalus(
+    "GB",
+    "sars_cov_1",
+    initial_state_manual = list(p_immune = p_immune),
+    time_end = 100
+  )
+  fs_1 <- get_epidemic_summary(out_1, "infections")$value
+  expect_lt(
+    fs_1,
+    fs_2
+  )
+})
+
 test_that("Initial state preparation:", {
+  country_canada <- daedalus_country("Canada")
   expect_error(
     daedalus(
       country_canada,


### PR DESCRIPTION
This patch version implements a request from UKHSA to allow modelling pre-existing immunity by placing some proportion of the model population in the vaccinated stratum during model initialisation, by specifying `p_immune` in `initial_state_manual` in `daedalus()` and `daedalus_multi_infection()`. See function documentation details for more.