### PR TITLE
Change behav mechanism epidemic signal to hosp cap

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: daedalus
 Title: Model Health, Social, and Economic Costs of a Pandemic
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("Pratik", "Gupte", , "p.gupte24@imperial.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-5294-7819")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# daedalus 0.3.1
+
+This patch version changes the new behavioural mechanism to be sensitive only to the hospital occupancy demand, rather than the ratio of hospital occupancy to surge hospital capacity.
+This change removes counter-intuitive perverse-incentive outcomes where increasing hospital capacity with the new behavioural mechanism active leads to more deaths.
+
+- The default value of the responsiveness parameter $k_2$ in `daedalus_new_behaviour()` has been changed to `0.0001` as it is now multiplied with the raw hospital occupancy.
+
+**Breaking change**
+
+The function signature for `daedalus_new_behaviour()` has changed and no longer accepts a `hospital_capacity` argument.
+
 # daedalus 0.3.0
 
 This is a minor version release for use in the Jameel Institute Symposium Daedalus preview event.

--- a/R/class_behaviour.R
+++ b/R/class_behaviour.R
@@ -114,10 +114,6 @@ daedalus_old_behaviour <- function(rate = 0.001, lower_limit = 0.2) {
 
 #' @name class_behaviour
 #'
-#' @param hospital_capacity The emergency hospital capacity of a country, but
-#' **may also be** a `<daedalus_country>` object from which the hospital
-#' capacity is extracted. See \eqn{\bar H} in Details.
-#'
 #' @param behav_effectiveness A single double value for the effectiveness of
 #' adopting behavioural measures against the risk of infection. Expected to be
 #' in the range \eqn{[0, 1]}, where 0 represents no effectiveness, and 1
@@ -130,7 +126,7 @@ daedalus_old_behaviour <- function(rate = 0.001, lower_limit = 0.2) {
 #'
 #' @param responsiveness A single double value for the population responsiveness
 #' to an epidemic signal. Must have a lower value of 0, but the upper bound is
-#' open. See \eqn{k_2} in Details. Defaults to 1.5.
+#' open. See \eqn{k_2} in Details. Defaults to 0.0001.
 #'
 #' @param k0 A single, optional double value which is a scaling parameter for
 #' the sigmoidal relationship between \eqn{p_t} and `behav_effectiveness`.
@@ -143,29 +139,12 @@ daedalus_old_behaviour <- function(rate = 0.001, lower_limit = 0.2) {
 #'
 #' @export
 daedalus_new_behaviour <- function(
-  hospital_capacity,
   behav_effectiveness = 0.5,
   baseline_optimism = 0.5,
-  responsiveness = 1.5,
+  responsiveness = 0.0001,
   k0 = 4.59,
   k1 = -9.19
 ) {
-  checkmate::assert_multi_class(
-    hospital_capacity,
-    c("numeric", "daedalus_country")
-  )
-
-  if (is_daedalus_country(hospital_capacity)) {
-    hospital_capacity <- get_data(hospital_capacity, "hospital_capacity")
-  } else {
-    checkmate::assert_number(
-      hospital_capacity,
-      lower = 1,
-      finite = TRUE,
-      .var.name = "hospital_capacity"
-    )
-  }
-
   checkmate::assert_number(
     behav_effectiveness,
     lower = 0,
@@ -201,7 +180,6 @@ daedalus_new_behaviour <- function(
   # note that this order is important and differs from the argument order
   # due to R argument convention (default valued args after others)
   parameters <- list(
-    hospital_capacity = hospital_capacity,
     behav_effectiveness = behav_effectiveness,
     baseline_optimism = baseline_optimism,
     k0 = k0,
@@ -260,7 +238,6 @@ validate_daedalus_behaviour <- function(x) {
     "lower_limit"
   )
   expected_fields_new <- c(
-    "hospital_capacity",
     "behav_effectiveness",
     "baseline_optimism",
     "k0",

--- a/inst/dust/daedalus.cpp
+++ b/inst/dust/daedalus.cpp
@@ -393,7 +393,7 @@ class daedalus_ode {
     // scale mortality rate by 1.6 if so
     Eigen::Tensor<double, 0> total_hosp =
         t_x.chip(iHr, i_COMPS).sum() + t_x.chip(iHd, i_COMPS).sum();
-    const double d_total_hosp = total_hosp(0) + 1.0;
+    const double d_total_hosp = total_hosp(0);
 
     const double hfr_modifier =
         daedalus::events::switch_by_flag(daedalus::constants::d_mort_multiplier,

--- a/inst/include/daedalus_behaviour.h
+++ b/inst/include/daedalus_behaviour.h
@@ -33,7 +33,6 @@ inline double scale_beta_old(const double &new_deaths,
 /// @brief New method of calculation public concern to scale transmission, based
 /// on assumed optimism and responsiveness.
 /// @param total_hosp The number of daily new hospitalisations.
-/// @param hosp_cap The country hospital capacity.
 /// @param delta Effectiveness of protective behaviour. Note that values are
 /// expected to be [0, 1], with 0 = no effect, 1 = fully effective.
 /// @param optimism Baseline optimism about the epidemic.
@@ -42,16 +41,14 @@ inline double scale_beta_old(const double &new_deaths,
 /// @param k1 Scaling factor for optimism.
 /// @param k2 Responsiveness to the epidemic signal (new hospitalisations).
 /// @return The scaling factor to reduce transmission rate.
-inline double scale_beta_new(const double &total_hosp, const double &hosp_cap,
-                             const double &delta, const double &optimism,
-                             const double &k0, const double &k1,
-                             const double &k2) {
+inline double scale_beta_new(const double &total_hosp, const double &delta,
+                             const double &optimism, const double &k0,
+                             const double &k1, const double &k2) {
   // proportion taking protective behaviour;
   // p_t = 1 / (1 + e^(-(k0 + k1 * B + k2 * hosp / hosp_capacity)))
   // NOTE: k1 is a negative value
   const double p_behav =
-      1.0 / (1.0 + std::exp(-(k0 + (k1 * optimism) +
-                              (k2 * (total_hosp / hosp_cap)))));
+      1.0 / (1.0 + std::exp(-(k0 + (k1 * optimism) + (k2 * (total_hosp)))));
 
   // scaling factor B =
   // p_t*delta*(p_t*delta + (1 - p_t)) + (1 - p_t)*(p_t*delta + (1 - p_t))
@@ -87,8 +84,8 @@ inline const std::function<double(double)> get_behav_fn(
     case 2: {
       behav_fn = [behav_params](double x) {
         return scale_beta_new(x, behav_params[0], behav_params[1],
-                              behav_params[2], behav_params[3], behav_params[4],
-                              behav_params[5]);
+                              behav_params[2], behav_params[3],
+                              behav_params[4]);
       };
       break;
     }

--- a/man/class_behaviour.Rd
+++ b/man/class_behaviour.Rd
@@ -11,10 +11,9 @@
 daedalus_old_behaviour(rate = 0.001, lower_limit = 0.2)
 
 daedalus_new_behaviour(
-  hospital_capacity,
   behav_effectiveness = 0.5,
   baseline_optimism = 0.5,
-  responsiveness = 1.5,
+  responsiveness = 1e-04,
   k0 = 4.59,
   k1 = -9.19
 )
@@ -30,10 +29,6 @@ additional daily death in the 'old' behavioural model.}
 \item{lower_limit}{The lower limit of the scaling factor in the 'old'
 behavioural model; prevents scaling factor from reaching zero.}
 
-\item{hospital_capacity}{The emergency hospital capacity of a country, but
-\strong{may also be} a \verb{<daedalus_country>} object from which the hospital
-capacity is extracted. See \eqn{\bar H} in Details.}
-
 \item{behav_effectiveness}{A single double value for the effectiveness of
 adopting behavioural measures against the risk of infection. Expected to be
 in the range \eqn{[0, 1]}, where 0 represents no effectiveness, and 1
@@ -46,7 +41,7 @@ See \eqn{\bar B} in Details. Defaults to 0.5.}
 
 \item{responsiveness}{A single double value for the population responsiveness
 to an epidemic signal. Must have a lower value of 0, but the upper bound is
-open. See \eqn{k_2} in Details. Defaults to 1.5.}
+open. See \eqn{k_2} in Details. Defaults to 0.0001.}
 
 \item{k0}{A single, optional double value which is a scaling parameter for
 the sigmoidal relationship between \eqn{p_t} and \code{behav_effectiveness}.

--- a/tests/testthat/_snaps/class_behaviour.md
+++ b/tests/testthat/_snaps/class_behaviour.md
@@ -15,10 +15,9 @@
     Message
       <daedalus_behaviour/daedalus_response>
       Behaviour model: new behaviour
-      hospital_capacity: 10000
       behav_effectiveness: 0.5
       baseline_optimism: 0.5
       k0: 4.59
       k1: -9.19
-      responsiveness: 1.5
+      responsiveness: 1e-04
 

--- a/tests/testthat/test-behaviour.R
+++ b/tests/testthat/test-behaviour.R
@@ -18,9 +18,7 @@ test_that("Behaviour mechanisms: work with daedalus()", {
     daedalus(
       "GBR",
       "sars_cov_1",
-      behaviour = daedalus_new_behaviour(
-        daedalus_country("GBR")
-      ),
+      behaviour = daedalus_new_behaviour(),
       time_end = 200
     )
   )
@@ -40,7 +38,7 @@ test_that("Behaviour mechanisms: work with daedalus()", {
   data_behav_new <- daedalus(
     "GBR",
     "sars_cov_1",
-    behaviour = daedalus_new_behaviour(daedalus_country("GBR")),
+    behaviour = daedalus_new_behaviour(),
     time_end = 200
   )
 
@@ -82,9 +80,7 @@ test_that("Behaviour mechanisms work with daedalus_multi_infection()", {
     daedalus_multi_infection(
       "GBR",
       infection_list,
-      behaviour = daedalus_new_behaviour(
-        daedalus_country("GBR")
-      ),
+      behaviour = daedalus_new_behaviour(),
       time_end = 20
     )
   )

--- a/tests/testthat/test-class_behaviour.R
+++ b/tests/testthat/test-class_behaviour.R
@@ -18,13 +18,10 @@ test_that("Class <daedalus_behaviour> works for original mechanism", {
 
 test_that("Class <daedalus_behaviour> works for new mechanism", {
   expect_no_condition(
-    daedalus_new_behaviour(1e4)
-  )
-  expect_no_condition(
-    daedalus_new_behaviour(daedalus_country("GB"))
+    daedalus_new_behaviour()
   )
 
-  behav <- daedalus_new_behaviour(1e4)
+  behav <- daedalus_new_behaviour()
   expect_s3_class(behav, c("daedalus_behaviour", "daedalus_response"))
   expect_identical(
     behav$identifier,
@@ -67,67 +64,54 @@ test_that("Class <daedalus_behaviour>: errors correctly", {
 
   # errors from daedalus_new_behaviour()
   expect_error(
-    daedalus_new_behaviour(-1e4),
-    "Assertion on 'hospital_capacity' failed: Element 1 is not >= 1"
-  )
-  expect_error(
-    daedalus_new_behaviour(c(1e4, 1e4)),
-    "Assertion on 'hospital_capacity' failed: Must have length 1."
-  )
-  expect_error(
-    daedalus_new_behaviour("1e4"),
-    "('hospital_capacity')*(inherit from class 'numeric'/'daedalus_country')"
-  )
-
-  expect_error(
-    daedalus_new_behaviour(1e4, -0.5),
+    daedalus_new_behaviour(-0.5),
     "Assertion on 'behav_effectiveness' failed: Element 1 is not >= 0"
   )
   expect_error(
-    daedalus_new_behaviour(1e4, c(0.5, 0.5)),
+    daedalus_new_behaviour(c(0.5, 0.5)),
     "Assertion on 'behav_effectiveness' failed: Must have length 1."
   )
   expect_error(
-    daedalus_new_behaviour(1e4, "0.5"),
+    daedalus_new_behaviour("0.5"),
     "Assertion on 'behav_effectiveness' failed: Must be of type 'number'"
   )
 
   expect_error(
-    daedalus_new_behaviour(1e4, 0.5, -1),
+    daedalus_new_behaviour(0.5, -1),
     "Assertion on 'baseline_optimism' failed: Element 1 is not >= 0"
   )
   expect_error(
-    daedalus_new_behaviour(1e4, 0.5, c(1, 1)),
+    daedalus_new_behaviour(0.5, c(1, 1)),
     "Assertion on 'baseline_optimism' failed: Must have length 1."
   )
   expect_error(
-    daedalus_new_behaviour(1e4, 0.5, c("1", "1")),
+    daedalus_new_behaviour(0.5, c("1", "1")),
     "Assertion on 'baseline_optimism' failed: Must be of type 'number'"
   )
 
   expect_error(
-    daedalus_new_behaviour(1e4, 0.5, 0.5, 1.5, -4),
+    daedalus_new_behaviour(0.5, 0.5, 1.5, -4),
     "Assertion on 'k0' failed: Element 1 is not >= 0"
   )
   expect_error(
-    daedalus_new_behaviour(1e4, 0.5, 0.5, 1.5, c(4, 4)),
+    daedalus_new_behaviour(0.5, 0.5, 1.5, c(4, 4)),
     "Assertion on 'k0' failed: Must have length 1."
   )
   expect_error(
-    daedalus_new_behaviour(1e4, 0.5, 0.5, 1.5, "4"),
+    daedalus_new_behaviour(0.5, 0.5, 1.5, "4"),
     "Assertion on 'k0' failed: Must be of type 'number'"
   )
 
   expect_error(
-    daedalus_new_behaviour(1e4, 0.5, 0.5, 1.5, 4, 1),
+    daedalus_new_behaviour(0.5, 0.5, 1.5, 4, 1),
     "Assertion on 'k1' failed: Element 1 is not <= 0"
   )
   expect_error(
-    daedalus_new_behaviour(1e4, 0.5, 0.5, 1.5, 4, c(-9, -9)),
+    daedalus_new_behaviour(0.5, 0.5, 1.5, 4, c(-9, -9)),
     "Assertion on 'k1' failed: Must have length 1."
   )
   expect_error(
-    daedalus_new_behaviour(1e4, 0.5, 0.5, 1.5, 4, "-9"),
+    daedalus_new_behaviour(0.5, 0.5, 1.5, 4, "-9"),
     "Assertion on 'k1' failed: Must be of type 'number'"
   )
 })


### PR DESCRIPTION
This PR fixes #135.

This patch version changes the new behavioural mechanism to be sensitive only to the hospital occupancy demand, rather than the ratio of hospital occupancy to surge hospital capacity.
This change removes counter-intuitive perverse-incentive outcomes where increasing hospital capacity with the new behavioural mechanism active leads to more deaths.

- The default value of the responsiveness parameter $k_2$ in `daedalus_new_behaviour()` has been changed to `0.0001` as it is now multiplied with the raw hospital occupancy.

**Breaking change**

The function signature for `daedalus_new_behaviour()` has changed and no longer accepts a `hospital_capacity` argument.

**Diagnostics**

See a visual diagnostic below, where changing hospital capacity does not influence the epidemic trajectory, whereas the level of optimism/concern does. I'm not entirely sure why there's a sharp transition in the incidence trajectory at around t = 100? My best guess is that the transition is at the point where $k_1 \bar B \approx k_2 H$ in the calculation of $p_t$ --- the proportion adopting behaviour ([see the docs](https://jameel-institute.github.io/daedalus/reference/class_behaviour.html#details)). After this point the $p_t$ value is probably mostly influenced by $k_2 H$ than the other two. $k_2$ might need tweaking if we don't like the look of these curves.

<img width="600" height="600" alt="fig_hospcap_optimism_new" src="https://github.com/user-attachments/assets/19d31777-1c00-42e6-b70c-28df8143fb30" />
